### PR TITLE
fix(ci): ship agents/ in the plugin distribution and assert it

### DIFF
--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -162,8 +162,11 @@ jobs:
           mkdir -p "$STAGING_DIR/server"
           cp -r .claude-plugin "$STAGING_DIR/"
           cp .mcp.json "$STAGING_DIR/"
-          cp -r skills "$STAGING_DIR/" 2>/dev/null || true
-          cp -r hooks "$STAGING_DIR/" 2>/dev/null || true
+          # No `|| true` on these: hooks/ and agents/ are runtime components of the
+          # plugin, not optional extras. A silenced copy is how `skills/` kept being
+          # staged for months after the directory was deleted, with nothing failing.
+          cp -r hooks "$STAGING_DIR/"
+          cp -r agents "$STAGING_DIR/"
           cp -r server/dist "$STAGING_DIR/server/"
           cp -r server/resources "$STAGING_DIR/server/"
           cp server/config.json "$STAGING_DIR/server/"
@@ -181,6 +184,11 @@ jobs:
           test -d "$VERIFY_DIR/server/resources"
           test -f "$VERIFY_DIR/.mcp.json"
           test -f "$VERIFY_DIR/.claude-plugin/plugin.json"
+          # chain-executor backs the `==>` delegation operator: response-assembler.ts
+          # and chain-operator-executor.ts both default agentType to 'chain-executor',
+          # so a dist branch without it breaks delegated chains for every installer.
+          test -f "$VERIFY_DIR/hooks/hooks.json"
+          test -f "$VERIFY_DIR/agents/chain-executor.md"
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v7
@@ -478,9 +486,9 @@ jobs:
           cp -r .claude-plugin .plugin-staging/
           cp .mcp.json .plugin-staging/
 
-          # Copy skills and hooks
-          cp -r skills .plugin-staging/ 2>/dev/null || true
-          cp -r hooks .plugin-staging/ 2>/dev/null || true
+          # Copy hooks and agents. No `|| true` — see the dist staging step above.
+          cp -r hooks .plugin-staging/
+          cp -r agents .plugin-staging/
 
           # Copy server (bundled - no node_modules needed)
           mkdir -p .plugin-staging/server
@@ -492,6 +500,8 @@ jobs:
           test -f .plugin-staging/server/dist/index.js
           test -f .plugin-staging/server/config.json
           test -d .plugin-staging/server/resources
+          test -f .plugin-staging/hooks/hooks.json
+          test -f .plugin-staging/agents/chain-executor.md
 
           # Create archive
           cd .plugin-staging

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -136,7 +136,7 @@ Push to main
 ### Setup
 
 ```bash
-# GitHub PAT (fine-grained, repo: claude-prompts-mcp)
+# GitHub PAT (fine-grained, repo: claude-prompts)
 # Permissions: Contents, Pull requests, Actions (read/write)
 gh secret set RELEASE_PLEASE_TOKEN
 

--- a/plans/claude-prompts-mcp.code-workspace
+++ b/plans/claude-prompts-mcp.code-workspace
@@ -4,9 +4,6 @@
 			"path": ".."
 		},
 		{
-			"path": "../../claude-prompts-plugin"
-		},
-		{
 			"path": "../../minipuft-plugins"
 		},
 		{

--- a/server/scripts/validate-versions.js
+++ b/server/scripts/validate-versions.js
@@ -106,7 +106,10 @@ const assertMarketplaceSource = (source) => {
   if (!source || source.source !== 'url') {
     throw new Error('Marketplace source must use url source');
   }
-  if (source.url !== 'https://github.com/minipuft/claude-prompts-mcp.git') {
+  // The repo was renamed claude-prompts-mcp -> claude-prompts. Assert the real name,
+  // not the rename redirect: a redirect the marketplace silently depends on breaks the
+  // day the old name is reclaimed, and this check is the only thing that would notice.
+  if (source.url !== 'https://github.com/minipuft/claude-prompts.git') {
     throw new Error(`Marketplace source url mismatch: ${source.url}`);
   }
   if (source.ref !== 'dist') {


### PR DESCRIPTION
## Problem

Neither plugin distribution artifact ships `agents/`.

Both staging blocks in `extension-publish.yml` (dist branch ~L157, release zip ~L481) copy `.claude-plugin`, `.mcp.json`, `hooks/`, `server/` — and nothing else.

`agents/chain-executor.md` is a **runtime component**, not a dev convenience:

| Site | Reference |
|---|---|
| `server/src/engine/execution/formatting/response-assembler.ts:289` | `nextStep?.agentType ?? 'chain-executor'` |
| `server/src/engine/execution/operators/chain-operator-executor.ts:615` | `?? 'chain-executor'` |
| `hooks/delegation-enforce.py:52` | `state.get("delegation_agent_type", "chain-executor")` |

So a chain using the `==>` delegation operator tells the host to spawn an agent that is not in the package. Confirmed from the consumer side against the live 3.0.0 marketplace entry:

```
$ claude plugin details claude-prompts@minipuft
Component inventory
  Skills (0)
  Agents (0)          <-- chain-executor missing
  Hooks (5)  PreToolUse, UserPromptSubmit, PostToolUse, Stop, SessionStart
  MCP servers (1)  claude-prompts
```

## Secondary: a silenced copy that had already failed

Both blocks ran:

```bash
cp -r skills … 2>/dev/null || true
cp -r hooks  … 2>/dev/null || true
```

There is no `skills/` at the repo root. That line has been a no-op, and nothing failed. The same `|| true` would have hidden `hooks/` disappearing just as quietly — the validate steps asserted the five `server/` and manifest paths but never `hooks/`.

## Changes

- stage `agents/` in both the dist tree and the plugin archive
- drop the dead `skills/` copy from both
- drop `|| true` from the `hooks/` copy — required, not optional
- assert `hooks/hooks.json` and `agents/chain-executor.md` in both validate steps

Also removes the stale `../../claude-prompts-plugin` entry from `plans/claude-prompts-mcp.code-workspace`. That directory holds one abandoned `plugin.json` (v1.0.0, Jan 3) whose declared `hooks`/`commands`/`skills`/`mcpServers` paths do not exist.

## Verification

- workflow YAML parses; `prettier --check` clean
- staging simulated locally against the `main` tree: both new asserts pass, `agents/chain-executor.md` present
- post-merge, re-running `Publish Extensions` should flip `claude plugin details` to `Agents (1)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBvV2djJzY2YAKG3tPjMED