### PR TITLE
refactor(server): subpath imports + declared public API contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,29 @@ system_control → SystemControl Router → 10 action handlers
 
 State stores using `kv_state` pass `tableName: 'kv_state'` + a discriminator `key` to `SqliteStateStoreConfig`. `SCHEMA_VERSION` bump triggers drop-and-recreate; no migration code since `state.db` is ephemeral.
 
+## Public API Contract (what a major version protects)
+
+**Declared surface over "anything that feels significant"; consumer-observable over internal.**
+
+Semver is defined relative to a declared API. Without one, every incidental change reads as
+breaking and major versions inflate until they carry no information.
+
+| In the contract -- break it, bump major | Not in the contract -- change freely |
+|------------------------------------------|----------------------------------------|
+| MCP tool surface: `prompt_engine`, `resource_manager`, `system_control` names, parameters, and response shape | Internal TypeScript exports, including `src/index.ts` |
+| CLI surface: `claude-prompts` and `cpm` commands and flags | `package.json` packaging fields (`types`, `exports`, `files`) |
+| Resource formats: prompt/gate/methodology YAML schema, `config.json` | `src/` layer structure, module layout, import style |
+| Python hook contract consumed by downstream plugins | Which files land in the published tarball |
+| Symbolic command language (`>>`, `==>`) | Build tooling, validation scripts, CI |
+
+**This package is a binary distribution** -- an MCP server, the `cpm` CLI, and Python hooks.
+It publishes no library API: `src/index.ts` exports only `startServer`, `gracefulShutdown`,
+`getApplicationHealth`, `getDetailedDiagnostics` (server lifecycle). Consumers run it; they do not
+import it. Adding a library surface is a deliberate act -- restore `types`, `exports["."].types`,
+`declaration: true` and `src` in `files` together, which `validate:package-entries` enforces.
+
+-> `CONTRIBUTING.md` §Breaking Changes for how to mark one.
+
 ## Key Constraints
 
 - **MCP Contract Dev**: Verify upstream first (`grep -rn "paramName" src/mcp-tools/*/core/manager.ts`). Layer alignment: Contract -> Generated -> Types -> Router -> Manager -> Service must agree.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,8 +184,28 @@ git commit -m "docs(guides): update injection control frequency table"
 git commit -m "refactor(runtime): extract module initialization to dedicated service"
 ```
 
-> [!NOTE]
-> Breaking changes: add `!` after type/scope (e.g., `feat(mcp-tools)!: redesign resource_manager schema`) and include a `BREAKING CHANGE:` footer.
+### Breaking Changes
+
+Add `!` after the type/scope (e.g. `feat(mcp-tools)!: redesign resource_manager schema`) **and** a
+`BREAKING CHANGE:` footer. Release Please reads either one to cut a major.
+
+**A change is breaking only if it alters the declared public API.** That surface is defined in
+`CLAUDE.md` § Public API Contract — the MCP tool surface, the CLI commands, the resource formats,
+the Python hook contract, and the symbolic command language. Internal TypeScript exports, package
+manifest fields, `src/` layout and build tooling are explicitly outside it.
+
+This distinction is the difference between a version number that means something and one that
+climbs on every refactor. When unsure, ask: **can a user observe this without reading our source?**
+If not, it is not breaking.
+
+| Change                                          | Breaking?                                  |
+| ----------------------------------------------- | ------------------------------------------ |
+| Rename a `prompt_engine` parameter              | **Yes** — MCP tool surface                 |
+| Remove a `cpm` flag                             | **Yes** — CLI surface                      |
+| Change the gate YAML schema                     | **Yes** — resource format                  |
+| Restructure `src/` layers, rewrite imports      | No — internal                              |
+| Drop `types` / `src` from the published package | No — packaging, no library API is declared |
+| Add a validation script or CI job               | No                                         |
 
 ## Testing
 

--- a/plans/techincal_debt/ci-enforcement-and-import-aliases-2026-07-31.md
+++ b/plans/techincal_debt/ci-enforcement-and-import-aliases-2026-07-31.md
@@ -8,22 +8,24 @@ more work is finalized for that release. Stacking is required, not preferred: `o
 10 `validate:all` members and 3 `validate-no-*` scripts against this branch's 21 and 8, so Tier 1
 cannot enforce guards that do not exist there, and #150 already modifies `ci.yml`.
 **Consequence**: this branch's PR shows #150's commits until #150 lands, and must merge after it.
-**Work type**: bug_fix (Tier 1–2), refactor (Tier 3, deferred)
-**Status**: **Tiers 1 and 2 complete** (2026-07-31, both gates passed). 1.4 held at ◐ by design
-until this branch merges. **Tier 3: 3.1 spike done — `#` confirmed**; it surfaced and fixed an
-unrelated packaging bug (`rootDir`). The 611-import codemod (3.2–3.6) stays deferred.
+**Work type**: bug_fix (Tier 1–2), refactor (Tier 3)
+**Status**: **Tiers 1, 2 and 3 complete** (2026-07-31, all gates passed). 1.4 held at ◐ by design
+until this branch merges.
 
 | Measure                                           | Before            | Now       | Target |
 | ------------------------------------------------- | ----------------- | --------- | ------ |
-| `validate:all` members enforced in CI             | **5/21**          | **26/26** | all    |
-| Recurrence guards (`validate:no-*`) run in CI     | **0/8**           | **8/8**   | 8/8    |
+| `validate:all` members enforced in CI             | **5/21**          | **28/28** | all    |
+| Recurrence guards (`validate:no-*`) run in CI     | **0/8**           | **9/9**   | all    |
 | Unpinned tool installs in workflows               | **2**             | **0**     | 0      |
 | Node version CI tests vs. Node version shipped    | 22.x/24           | 22.x+24   | same   |
 | Dead steps in `.husky/pre-push`                   | **1**             | **0**     | 0      |
 | PR classes that can never satisfy required checks | **1** (docs-only) | **0**     | 0      |
+| Cross-layer relative imports in `src/`            | **614**           | **0**     | 0      |
+| Resolver configs holding a copy of the alias map  | **3**             | **1**     | 1      |
 
-`validate:all` grew 21 → 26 across the three tiers (`validate:required-contexts`,
-`validate:format`, `validate:package-entries`, plus two self-tests). It also
+`validate:all` grew 21 → 28 across the three tiers (`validate:required-contexts`,
+`validate:format`, `validate:package-entries`, `validate:no-crosslayer-relative`, plus three
+self-tests). It also
 **exited 1 on committed HEAD** when Tier 1 started — `validate:documented-options` flagged npm's
 own `--prefix` as an undocumented flag of ours. Nothing caught it because nothing ran it. That is
 F2 demonstrating itself, not a side issue.
@@ -474,11 +476,54 @@ dist) **before** rewriting 611 imports, because the answer determines what the c
 | #   | Step                                                                                                                                                        | Status |
 | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
 | 3.1 | Spike: 10 files, build, inspect emitted `.d.ts`. Decides `#` vs `@` vs abandon                                                                              | ✓      |
-| 3.2 | Declare `imports` in `server/package.json`; extend to `runtime/` and `cli-shared/`, which the current map omits                                             | ☐      |
-| 3.3 | ts-morph codemod over the **611 cross-layer imports only** — resolve each specifier, rewrite only on layer crossing. Leave the 501 `./` and 388 `../` alone | ☐      |
-| 3.4 | ESLint `no-restricted-imports` banning `../../*` — without this the sweep decays                                                                            | ☐      |
-| 3.5 | Update `import/order` `pathGroups`: `eslint.config.mjs:106` matches `@/**`, which matches nothing here                                                      | ☐      |
-| 3.6 | Confirm `validate:arch` still resolves — `.dependency-cruiser.cjs` sets `tsConfig`, so it maps aliases to real paths before matching `^src/shared/`         | ☐      |
+| 3.2 | Declare `imports` in `server/package.json`; extend to `runtime/` and `cli-shared/`, which the current map omits                                             | ✓      |
+| 3.3 | ts-morph codemod over the **611 cross-layer imports only** — resolve each specifier, rewrite only on layer crossing. Leave the 501 `./` and 388 `../` alone | ✓      |
+| 3.4 | ~~ESLint `no-restricted-imports` banning `../../*`~~ → **`validate:no-crosslayer-relative`** (see Deviations)                                               | ✓      |
+| 3.5 | Update `import/order` `pathGroups`: matched `@/**`, which matches nothing here                                                                              | ✓      |
+| 3.6 | Confirm `validate:arch` still resolves                                                                                                                      | ✓      |
+
+**Package shape decided**: this is a **binary distribution, not a library**. `.mcpbignore` excludes
+`server/src` from the extension, `manifest.json` points at `dist/index.js`, and neither downstream
+plugin contains a single `import … from 'claude-prompts'` — they depend on it for the server binary
+and the Python hooks. So `types`, `exports["."].types`, declaration emit, and `src` in `files` were
+all removed, and `imports → ./src/*` is correct by construction because the only reader is us.
+
+### Gate verdict — PASS (executed 2026-07-31)
+
+| Claim                             | Proof                                                                                          |
+| --------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 614 cross-layer imports rewritten | ts-morph codemod: 614 rewritten, 972 intra-layer untouched, **0 unresolved**, 239 files        |
+| Every resolver honours `#`        | tsc **0** · esbuild **0** · Jest **1732/1732** · depcruise **608 `#` edges, 0 unresolvable**   |
+| The runtime actually works        | `verify:mcp` **11/11** against a server spawned from the new bundle                            |
+| The `cpm` CLI still resolves      | cli typecheck **0**, build **0**, tests **75/75** — it reaches into `server/src` cross-package |
+| The migration cannot decay        | `validate:no-crosslayer-relative`, 6/6 self-test rules; a fresh violation exits 1              |
+| The package shape cannot regress  | `validate:package-entries`, 8/8 rules incl. both binary and library shapes                     |
+
+Tier-wide: `validate:all` **0** (28 members) · ratchet 3475 (below the 3477 baseline).
+
+### Deviations
+
+1. **3.4 — ESLint was the wrong instrument; wrote a resolving guard instead.** The planned
+   `no-restricted-imports` ban on `../../*` produced **197 violations, of which 0 were genuinely
+   cross-layer.** `mcp/tools/handlers/x.ts` importing `../../schemas/y.js` never leaves `mcp` —
+   textual matching cannot tell a cross-layer hop from deep intra-layer nesting. This is the same
+   argument that chose ts-morph over sed for the codemod, and it applies just as much to the guard.
+   `validate:no-crosslayer-relative` resolves each specifier with path arithmetic (relative
+   specifiers are pure paths, so no compiler is needed) and flags only real crossings.
+
+2. **The guard immediately caught a gap in my own codemod.** It found 10 surviving cross-layer
+   imports in 8 files: inline `import('…')` **type nodes**. The codemod handled import declarations,
+   export declarations and dynamic-import call expressions — an `ImportTypeNode` is none of those.
+   Fixed in a follow-up pass. Had the guard not existed, those 10 would have shipped as the seed of
+   the decay it exists to prevent.
+
+3. **`rootDir` was load-bearing twice.** It is required for `imports` to resolve at all
+   (`TS2210: the project root is ambiguous`) — the same missing option that broke the published
+   `types` entry. One line fixed both, which is why the packaging fix landed before the codemod.
+
+4. **`import/order` needed a re-sort, not just a pathGroup change.** Switching `@/**` → `#**`
+   produced +292 ordering errors; `eslint --fix` cleared all but 2, which needed manual work because
+   `export` statements sat between imports and the autofixer will not move across them.
 
 **Not** `ast-grep` or `sed`: deciding whether an import crosses a layer requires _resolving_ the
 specifier, not matching its text. ts-morph is already a devDependency. The recorded ts-morph caveat

--- a/server/esbuild.config.mjs
+++ b/server/esbuild.config.mjs
@@ -10,7 +10,6 @@
  */
 
 import * as esbuild from 'esbuild';
-import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -87,14 +86,8 @@ var __dirname = __pathDirname(__filename);`,
     'process.env.BUILD_TIME': JSON.stringify(new Date().toISOString()),
   },
 
-  // Path aliases matching tsconfig.json paths
-  alias: {
-    '@shared': './src/shared',
-    '@infra': './src/infra',
-    '@engine': './src/engine',
-    '@modules': './src/modules',
-    '@mcp': './src/mcp',
-  },
+  // No `alias` block. Subpath imports are declared once in package.json "imports", which
+  // esbuild resolves natively — no second copy of the map to drift out of sync.
 
   // Enable tree-shaking
   treeShaking: true,
@@ -166,12 +159,11 @@ async function build() {
         console.log(`\nSkipping cpm CLI: ${CLI_ENTRY} not present (expected in the Docker build).`);
       }
 
-      // Generate type declarations (consumed via package.json "types" field)
-      console.log('Generating type declarations...');
-      execSync('npx tsc --emitDeclarationOnly --declaration --outDir dist', {
-        stdio: 'inherit',
-        cwd: __dirname,
-      });
+      // No declaration emit. This package ships a server binary and Python hooks, not a
+      // library — nothing imports it, so the 405 .d.ts files this produced were read by
+      // no one, and the "types" entry backing them pointed at a path that did not exist.
+      // Restore this step alongside a real consumer, together with package.json "types"
+      // and a smoke test that typechecks against `npm pack` output.
 
       console.log(`\nBuild complete: dist/index.js${builtCli ? ', dist/cpm.js' : ''}`);
     }

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -103,9 +103,11 @@ export default [
             'object',
             'type',
           ],
+          // `@/**` matched nothing — this repo never used that prefix. Subpath imports
+          // (package.json "imports") are the internal-module form.
           pathGroups: [
             {
-              pattern: '@/**',
+              pattern: '#**',
               group: 'internal',
               position: 'before',
             },
@@ -121,6 +123,12 @@ export default [
       'import/no-duplicates': 'error',
       'import/no-cycle': 'error',
       'import/newline-after-import': 'error',
+
+      // Cross-layer relative imports are enforced by `validate:no-crosslayer-relative`,
+      // NOT by no-restricted-imports. A textual `../../*` ban flags 197 legitimate deep
+      // intra-layer imports and zero real violations: `mcp/tools/handlers/x.ts` importing
+      // `../../schemas/y.js` never leaves `mcp`. Whether an import crosses a layer is a
+      // question about the resolved path, so the guard resolves it.
 
       // General rules - warn on all console usage, use EnhancedLogger instead
       'no-console': 'warn',
@@ -270,9 +278,11 @@ export default [
             'object',
             'type',
           ],
+          // `@/**` matched nothing — this repo never used that prefix. Subpath imports
+          // (package.json "imports") are the internal-module form.
           pathGroups: [
             {
-              pattern: '@/**',
+              pattern: '#**',
               group: 'internal',
               position: 'before',
             },

--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -44,11 +44,17 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'mjs'],
   // Handle ES module imports properly - map .js imports to TypeScript files and preserve ES modules
   moduleNameMapper: {
-    '^@shared/(.*)$': '<rootDir>/src/shared/$1',
-    '^@infra/(.*)$': '<rootDir>/src/infra/$1',
-    '^@engine/(.*)$': '<rootDir>/src/engine/$1',
-    '^@modules/(.*)$': '<rootDir>/src/modules/$1',
-    '^@mcp/(.*)$': '<rootDir>/src/mcp/$1',
+    // Subpath imports (package.json "imports"). Jest resolves the `imports` field, but the
+    // mapped target keeps the NodeNext `.js` extension while the file on disk is `.ts` —
+    // the same reason the relative-import rule below exists. Mapping here strips both the
+    // prefix and the extension in one step.
+    '^#shared/(.*)\\.js$': '<rootDir>/src/shared/$1',
+    '^#infra/(.*)\\.js$': '<rootDir>/src/infra/$1',
+    '^#engine/(.*)\\.js$': '<rootDir>/src/engine/$1',
+    '^#modules/(.*)\\.js$': '<rootDir>/src/modules/$1',
+    '^#mcp/(.*)\\.js$': '<rootDir>/src/mcp/$1',
+    '^#runtime/(.*)\\.js$': '<rootDir>/src/runtime/$1',
+    '^#cli-shared/(.*)\\.js$': '<rootDir>/src/cli-shared/$1',
     '^(?:\\.{1,2}/)+dist/(.*)\\.js$': '<rootDir>/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
     // node:sqlite is a native Node.js built-in (>=22); shim for Jest's module resolver

--- a/server/package.json
+++ b/server/package.json
@@ -10,16 +10,22 @@
     "claude-prompts": "./dist/index.js",
     "cpm": "./dist/cpm.js"
   },
-  "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.js"
     }
+  },
+  "imports": {
+    "#shared/*": "./src/shared/*",
+    "#infra/*": "./src/infra/*",
+    "#engine/*": "./src/engine/*",
+    "#modules/*": "./src/modules/*",
+    "#mcp/*": "./src/mcp/*",
+    "#runtime/*": "./src/runtime/*",
+    "#cli-shared/*": "./src/cli-shared/*"
   },
   "files": [
     "dist",
-    "src",
     "config.json",
     "resources",
     "hooks",
@@ -92,6 +98,8 @@
     "validate:no-stepstate": "node scripts/validate-no-stepstate.js",
     "validate:no-methodology-vocab": "node scripts/validate-no-methodology-vocab.js",
     "validate:no-execution-mode": "node scripts/validate-no-execution-mode.js",
+    "validate:no-crosslayer-relative": "node scripts/validate-no-crosslayer-relative.js",
+    "validate:no-crosslayer-relative:self-test": "node scripts/validate-no-crosslayer-relative.js --self-test",
     "validate:documented-options": "node scripts/validate-documented-options.js",
     "validate:required-contexts": "node scripts/validate-required-contexts.js",
     "validate:required-contexts:self-test": "node scripts/validate-required-contexts.js --self-test",
@@ -102,7 +110,7 @@
     "validate:dist-fresh": "bash scripts/validate-dist-fresh.sh",
     "validate:extension-deps": "node scripts/validate-extension-deps.js",
     "validate:python": "cd .. && ruff check hooks/ && ruff format --check hooks/ && pyrefly check --baseline hooks/.pyrefly-baseline.json",
-    "validate:all": "npm run lint:ratchet && npm run validate:format && npm run validate:arch && npm run validate:filesize && npm run validate:metadata && npm run validate:contracts && npm run validate:python && npm run validate:frameworks && npm run validate:gate-index && npm run validate:versions && npm run validate:extension-deps && npm run validate:readme && npm run validate:no-legacy-sidecars && npm run validate:no-prompt-gates-alias && npm run validate:no-tool-layer-validator-imports && npm run validate:no-crosslayer-reexport && npm run validate:no-chainsessionmanager && npm run validate:no-stepstate && npm run validate:no-methodology-vocab && npm run validate:no-execution-mode && npm run validate:documented-options && npm run validate:required-contexts && npm run validate:package-entries && npm run verify:mcp:self-test && npm run validate:required-contexts:self-test && npm run validate:package-entries:self-test",
+    "validate:all": "npm run lint:ratchet && npm run validate:format && npm run validate:arch && npm run validate:filesize && npm run validate:metadata && npm run validate:contracts && npm run validate:python && npm run validate:frameworks && npm run validate:gate-index && npm run validate:versions && npm run validate:extension-deps && npm run validate:readme && npm run validate:no-legacy-sidecars && npm run validate:no-prompt-gates-alias && npm run validate:no-tool-layer-validator-imports && npm run validate:no-crosslayer-reexport && npm run validate:no-chainsessionmanager && npm run validate:no-stepstate && npm run validate:no-methodology-vocab && npm run validate:no-execution-mode && npm run validate:no-crosslayer-relative && npm run validate:documented-options && npm run validate:required-contexts && npm run validate:package-entries && npm run verify:mcp:self-test && npm run validate:required-contexts:self-test && npm run validate:package-entries:self-test && npm run validate:no-crosslayer-relative:self-test",
     "verify:action-metadata": "tsx scripts/verify-action-inventory.ts",
     "dev:graph": "madge --ts-config ./tsconfig.json --extensions ts src --image graph.svg",
     "dev:graph:json": "madge --ts-config ./tsconfig.json --extensions ts src --json",

--- a/server/scripts/validate-no-crosslayer-relative.js
+++ b/server/scripts/validate-no-crosslayer-relative.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+/**
+ * Guards the subpath-import migration against decay.
+ *
+ * 614 cross-layer relative imports were rewritten to package.json "imports" specifiers
+ * (`#shared/x.js` rather than `../../shared/x.js`). The subpath form names the layer it
+ * comes from and stays correct when the importing file moves; a `../../` chain encodes the
+ * importer's depth into the specifier, so moving the file silently changes what it means.
+ *
+ * WHY NOT ESLint `no-restricted-imports`
+ * It matches specifier TEXT. Banning `../../*` flags 197 legitimate deep intra-layer
+ * imports — `mcp/tools/handlers/x.ts` importing `../../schemas/y.js` never leaves `mcp` —
+ * and catches zero real violations. Whether an import crosses a layer is a question about
+ * the RESOLVED path, which is the same reason the migration used ts-morph and not sed.
+ *
+ * Resolution here is pure path arithmetic: a relative specifier is a path, so `path.resolve`
+ * answers it exactly without loading the TypeScript program.
+ *
+ * Intra-layer relative imports are left alone on purpose. `#shared/foo.js` for a sibling is
+ * noise; `./foo.js` says "next to me", which is information.
+ *
+ * `--self-test` proves the rule can still fail.
+ *
+ * RETIREMENT CONDITION: delete when no contributor could plausibly write a cross-layer
+ * relative import, i.e. when the subpath form has been the only one for a full release.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SERVER = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = path.join(SERVER, 'src');
+
+/** Top-level directories under src/ that package.json "imports" exposes. */
+const LAYERS = new Set(['shared', 'infra', 'engine', 'modules', 'mcp', 'runtime', 'cli-shared']);
+
+/** Matches the specifier in `from '…'`, `import('…')` and `export … from '…'`. */
+const SPECIFIER = /(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g;
+
+/** The layer a file belongs to, or null for files sitting directly in src/. */
+function layerOf(absPath) {
+  const rel = path.relative(SRC, absPath);
+  if (rel.startsWith('..')) return null;
+  const [top] = rel.split(path.sep);
+  return top && LAYERS.has(top) ? top : null;
+}
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else if (/\.tsx?$/.test(full)) yield full;
+  }
+}
+
+/**
+ * Returns the cross-layer relative imports in one file's source text.
+ * Pure — the self-test drives it with fabricated inputs.
+ */
+function findViolations(absPath, source) {
+  const fromLayer = layerOf(absPath);
+  if (!fromLayer) return [];
+
+  const violations = [];
+  for (const [, specifier] of source.matchAll(SPECIFIER)) {
+    if (!specifier.startsWith('.')) continue;
+
+    const targetLayer = layerOf(path.resolve(path.dirname(absPath), specifier));
+    if (targetLayer && targetLayer !== fromLayer) {
+      violations.push({ specifier, fromLayer, targetLayer });
+    }
+  }
+  return violations;
+}
+
+/** Each case must produce at least one violation, or the rule it exercises is inert. */
+const SELF_TEST_CASES = [
+  {
+    rule: 'a cross-layer ../../ import is rejected',
+    file: path.join(SRC, 'mcp', 'tools', 'handler.ts'),
+    source: "import { Logger } from '../../infra/logging/index.js';",
+    expectViolation: true,
+  },
+  {
+    rule: 'a cross-layer import at any depth is rejected',
+    file: path.join(SRC, 'mcp', 'a', 'b', 'c', 'deep.ts'),
+    source: "export { x } from '../../../../shared/x.js';",
+    expectViolation: true,
+  },
+  {
+    rule: 'a cross-layer dynamic import is rejected',
+    file: path.join(SRC, 'engine', 'gates', 'g.ts'),
+    source: "const m = await import('../../modules/prompts/index.js');",
+    expectViolation: true,
+  },
+  {
+    rule: 'a deep INTRA-layer import is accepted (the eslint rule got this wrong)',
+    file: path.join(SRC, 'mcp', 'tools', 'handlers', 'x.ts'),
+    source: "import { y } from '../../schemas/y.js';",
+    expectViolation: false,
+  },
+  {
+    rule: 'the subpath form is accepted',
+    file: path.join(SRC, 'mcp', 'tools', 'handler.ts'),
+    source: "import { Logger } from '#infra/logging/index.js';",
+    expectViolation: false,
+  },
+  {
+    rule: 'a sibling import is accepted',
+    file: path.join(SRC, 'mcp', 'tools', 'handler.ts'),
+    source: "import { y } from './y.js';",
+    expectViolation: false,
+  },
+];
+
+function runSelfTest() {
+  console.log('\nvalidate:no-crosslayer-relative self-test — every rule must behave\n');
+
+  let failures = 0;
+  for (const { rule, file, source, expectViolation } of SELF_TEST_CASES) {
+    const got = findViolations(file, source).length > 0;
+    const ok = got === expectViolation;
+    console.log(`  ${ok ? 'ok  ' : 'FAIL'}  ${rule}`);
+    if (!ok) failures += 1;
+  }
+
+  console.log(
+    failures === 0
+      ? `\nOK: all ${SELF_TEST_CASES.length} rules are falsifiable\n`
+      : `\nFAILED: ${failures} rule(s) behaved wrongly\n`
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    runSelfTest();
+    return;
+  }
+
+  const offenders = [];
+  for (const file of walk(SRC)) {
+    for (const violation of findViolations(file, readFileSync(file, 'utf8'))) {
+      offenders.push(
+        `  ${path.relative(SERVER, file)}\n` +
+          `    ${violation.specifier}  (${violation.fromLayer} -> ${violation.targetLayer}) ` +
+          `use #${violation.targetLayer}/…`
+      );
+    }
+  }
+
+  if (offenders.length > 0) {
+    console.error(`Cross-layer relative imports found (${offenders.length}):\n`);
+    console.error(offenders.join('\n'));
+    console.error(
+      '\nUse the subpath form declared in package.json "imports". It names the layer ' +
+        "rather than the importer's depth, so it survives the file moving."
+    );
+    process.exit(1);
+  }
+
+  console.log('No cross-layer relative imports found.');
+}
+
+main();

--- a/server/scripts/validate-package-entries.js
+++ b/server/scripts/validate-package-entries.js
@@ -69,15 +69,45 @@ function findViolations(pkg, compilerOptions, distExists, fileExists) {
     ['types', pkg.types && `./${pkg.types.replace(/^\.\//, '')}`],
     ['exports["."].types', pkg.exports?.['.']?.types],
   ];
+  const declaresTypes = declared.some(([, value]) => Boolean(value));
+  const emitsDeclarations = compilerOptions.declaration === true;
 
-  for (const [label, value] of declared) {
-    if (!value) {
-      violations.push(`${label} is not declared; consumers get no types.`);
-    } else if (value !== expected) {
+  // This package ships a binary, not a library — no `types`, no declaration emit. Both
+  // halves must agree: advertising types nothing emits is the original bug, and emitting
+  // 405 declarations nothing advertises is the dead weight that hid it.
+  if (declaresTypes !== emitsDeclarations) {
+    violations.push(
+      declaresTypes
+        ? 'package.json advertises a types entry but tsconfig does not set `declaration: true`, ' +
+            'so nothing emits it. Either drop the types entry or turn declaration emit back on.'
+        : 'tsconfig sets `declaration: true` but package.json advertises no types entry, so the ' +
+            'emitted declarations are unreachable. Either declare `types` or drop the emit.'
+    );
+  }
+
+  // Only meaningful when the package claims to be consumable as a library.
+  if (declaresTypes) {
+    for (const [label, value] of declared) {
+      if (!value) {
+        violations.push(`${label} is missing while its counterpart is declared; they must agree.`);
+      } else if (value !== expected) {
+        violations.push(
+          `${label} is ${JSON.stringify(value)} but tsc emits to ${JSON.stringify(expected)} ` +
+            `(rootDir ${JSON.stringify(rootDir)}, outDir ${JSON.stringify(outDir)}). ` +
+            `The advertised path does not exist, so the package ships no reachable types.`
+        );
+      }
+    }
+  }
+
+  // Every subpath in package.json "imports" must point at a directory that exists —
+  // a dangling entry fails at resolution time in whichever tool hits it first.
+  for (const [subpath, target] of Object.entries(pkg.imports ?? {})) {
+    if (typeof target !== 'string') continue;
+    const dir = target.replace(/^\.\//, '').replace(/\/\*$/, '');
+    if (!fileExists(dir)) {
       violations.push(
-        `${label} is ${JSON.stringify(value)} but tsc emits to ${JSON.stringify(expected)} ` +
-          `(rootDir ${JSON.stringify(rootDir)}, outDir ${JSON.stringify(outDir)}). ` +
-          `The advertised path does not exist, so the package ships no reachable types.`
+        `imports["${subpath}"] points at ${JSON.stringify(target)}, whose directory does not exist.`
       );
     }
   }
@@ -99,33 +129,49 @@ function findViolations(pkg, compilerOptions, distExists, fileExists) {
   return violations;
 }
 
-const OK_TSCONFIG = { rootDir: './src', outDir: 'dist' };
-const OK_PKG = {
+/** The library shape: declares types AND emits them. */
+const LIB_TSCONFIG = { rootDir: './src', outDir: 'dist', declaration: true };
+const LIB_PKG = {
   types: 'dist/index.d.ts',
   exports: { '.': { types: './dist/index.d.ts' } },
 };
+
+/** The binary shape this package actually ships: no types, no declaration emit. */
+const BIN_TSCONFIG = { rootDir: './src', outDir: 'dist' };
+const BIN_PKG = { exports: { '.': { import: './dist/index.js' } } };
 
 /** Each case must produce at least one violation, or the rule it exercises is inert. */
 const SELF_TEST_CASES = [
   {
     rule: 'missing rootDir is rejected',
-    pkg: OK_PKG,
-    tsconfig: { outDir: 'dist' },
+    pkg: LIB_PKG,
+    tsconfig: { outDir: 'dist', declaration: true },
   },
   {
     rule: 'the original bug is rejected (types at dist/index.d.ts, emit at dist/src/)',
-    pkg: OK_PKG,
-    tsconfig: { rootDir: '.', outDir: 'dist' },
+    pkg: LIB_PKG,
+    tsconfig: { rootDir: '.', outDir: 'dist', declaration: true },
   },
   {
-    rule: 'a missing types field is rejected',
-    pkg: { exports: { '.': { types: './dist/index.d.ts' } } },
-    tsconfig: OK_TSCONFIG,
+    rule: 'advertising types with no declaration emit is rejected',
+    pkg: LIB_PKG,
+    tsconfig: BIN_TSCONFIG,
+  },
+  {
+    rule: 'emitting declarations nothing advertises is rejected',
+    pkg: BIN_PKG,
+    tsconfig: LIB_TSCONFIG,
   },
   {
     rule: 'types and exports disagreeing is rejected',
     pkg: { types: 'dist/index.d.ts', exports: { '.': { types: './dist/main.d.ts' } } },
-    tsconfig: OK_TSCONFIG,
+    tsconfig: LIB_TSCONFIG,
+  },
+  {
+    rule: 'a dangling imports subpath is rejected',
+    pkg: { ...BIN_PKG, imports: { '#gone/*': './src/gone/*' } },
+    tsconfig: BIN_TSCONFIG,
+    fileExists: () => false,
   },
 ];
 
@@ -133,19 +179,24 @@ function runSelfTest() {
   console.log('\nvalidate:package-entries self-test — every rule must reject a wrong input\n');
 
   let failures = 0;
-  for (const { rule, pkg, tsconfig } of SELF_TEST_CASES) {
-    const rejected = findViolations(pkg, tsconfig, false, () => true).length > 0;
+  for (const { rule, pkg, tsconfig, fileExists } of SELF_TEST_CASES) {
+    const rejected = findViolations(pkg, tsconfig, false, fileExists ?? (() => true)).length > 0;
     console.log(`  ${rejected ? 'ok  ' : 'FAIL'}  ${rule}`);
     if (!rejected) failures += 1;
   }
 
-  const cleanOk = findViolations(OK_PKG, OK_TSCONFIG, false, () => true).length === 0;
-  console.log(`  ${cleanOk ? 'ok  ' : 'FAIL'}  a correct package is accepted`);
-  if (!cleanOk) failures += 1;
+  for (const [shape, pkg, tsconfig] of [
+    ['binary', BIN_PKG, BIN_TSCONFIG],
+    ['library', LIB_PKG, LIB_TSCONFIG],
+  ]) {
+    const ok = findViolations(pkg, tsconfig, false, () => true).length === 0;
+    console.log(`  ${ok ? 'ok  ' : 'FAIL'}  a correct ${shape} package is accepted`);
+    if (!ok) failures += 1;
+  }
 
   console.log(
     failures === 0
-      ? `\nOK: all ${SELF_TEST_CASES.length + 1} rules are falsifiable\n`
+      ? `\nOK: all ${SELF_TEST_CASES.length + 2} rules are falsifiable\n`
       : `\nFAILED: ${failures} rule(s) cannot detect a wrong input\n`
   );
   process.exit(failures === 0 ? 0 : 1);

--- a/server/src/cli-shared/index.ts
+++ b/server/src/cli-shared/index.ts
@@ -34,7 +34,7 @@ export {
   type PromptYaml,
   type PromptYamlValidationResult,
   type PromptSchemaValidationResult,
-} from '../modules/prompts/prompt-schema.js';
+} from '#modules/prompts/prompt-schema.js';
 
 // ── Gate schemas (pure Zod) ──────────────────────────────────────────────────
 
@@ -50,7 +50,7 @@ export {
   type GateRetryConfigYaml,
   type GateDefinitionYaml,
   type GateSchemaValidationResult,
-} from '../engine/gates/core/gate-schema.js';
+} from '#engine/gates/core/gate-schema.js';
 
 // ── Framework schemas (pure Zod) ──────────────────────────────────────────
 
@@ -63,7 +63,7 @@ export {
   type TemplateSuggestion,
   type FrameworkYaml,
   type FrameworkSchemaValidationResult,
-} from '../engine/frameworks/definitions/framework-schema.js';
+} from '#engine/frameworks/definitions/framework-schema.js';
 
 // ── Style schemas (pure Zod) ────────────────────────────────────────────────
 
@@ -75,7 +75,7 @@ export {
   type StyleActivationYaml,
   type StyleDefinitionYaml,
   type StyleSchemaValidationResult,
-} from '../modules/formatting/core/style-schema.js';
+} from '#modules/formatting/core/style-schema.js';
 
 // ── YAML utilities (js-yaml + node:fs only) ─────────────────────────────────
 
@@ -97,7 +97,7 @@ export {
   type YamlParseResult,
   type YamlFileLoadOptions,
   type YamlFileLoadResult,
-} from '../shared/utils/yaml/index.js';
+} from '#shared/utils/yaml/index.js';
 
 // ── Versioning types (pure interfaces) ───────────────────────────────────────
 
@@ -107,7 +107,7 @@ export type {
   SaveVersionResult,
   RollbackResult,
   SaveVersionOptions,
-} from '../modules/versioning/types.js';
+} from '#modules/versioning/types.js';
 
 // ── Version history (standalone, node:fs only) ──────────────────────────────
 

--- a/server/src/cli-shared/resource-operations.ts
+++ b/server/src/cli-shared/resource-operations.ts
@@ -31,7 +31,8 @@ import {
   validateResourceFile,
 } from './resource-validation.js';
 import { renameHistoryResource } from './version-history.js';
-import { loadYamlFileSync, serializeYaml } from '../shared/utils/yaml/index.js';
+
+import { loadYamlFileSync, serializeYaml } from '#shared/utils/yaml/index.js';
 
 // ── Result types ────────────────────────────────────────────────────────────
 

--- a/server/src/cli-shared/resource-validation.ts
+++ b/server/src/cli-shared/resource-validation.ts
@@ -4,7 +4,7 @@ import {
   type ResourceVerificationIssue,
   type ResourceVerificationResult,
   type ResourceVerificationType,
-} from '../modules/resources/services/resource-verification-service.js';
+} from '#modules/resources/services/resource-verification-service.js';
 
 export type ResourceValidationType = Exclude<ResourceVerificationType, 'tools'>;
 export type ResourceValidationIssue = ResourceVerificationIssue;

--- a/server/src/cli-shared/version-history.ts
+++ b/server/src/cli-shared/version-history.ts
@@ -15,7 +15,7 @@ import type {
   SaveVersionResult,
   RollbackResult,
   SaveVersionOptions,
-} from '../modules/versioning/types.js';
+} from '#modules/versioning/types.js';
 
 const DEFAULT_MAX_VERSIONS = 50;
 

--- a/server/src/engine/execution/capture/step-capture-service.ts
+++ b/server/src/engine/execution/capture/step-capture-service.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Captures step results (placeholder or real) in chain sessions.
 
-import type { Logger } from '../../../infra/logging/index.js';
-import type { ChainSession, ChainSessionService } from '../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSession, ChainSessionService } from '#shared/types/index.js';
 import type { ExecutionContext, SessionContext } from '../context/index.js';
 
 const PLACEHOLDER_SOURCE = 'StepResponseCaptureStage';

--- a/server/src/engine/execution/context/context-resolver.ts
+++ b/server/src/engine/execution/context/context-resolver.ts
@@ -13,9 +13,9 @@
  * - Context caching for performance
  */
 
-import { Logger } from '../../../infra/logging/index.js';
+import type { PromptArgument } from '#shared/types/index.js';
 
-import type { PromptArgument } from '../../../shared/types/index.js';
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Context source types

--- a/server/src/engine/execution/context/context-types.ts
+++ b/server/src/engine/execution/context/context-types.ts
@@ -7,7 +7,7 @@
  * circular dependencies.
  */
 
-import type { PendingGateReview } from '../../../shared/types/chain-execution.js';
+import type { PendingGateReview } from '#shared/types/chain-execution.js';
 import type { ChainStepPrompt } from '../operators/types.js';
 import type { CommandParseResult } from '../parsers/command-parser.js';
 import type { ConvertedPrompt, ExecutionModifiers } from '../types.js';

--- a/server/src/engine/execution/context/execution-context.ts
+++ b/server/src/engine/execution/context/execution-context.ts
@@ -1,10 +1,13 @@
 // @lifecycle canonical - Holds runtime execution context data and helpers.
-import { noopLogger } from '../../../infra/logging/index.js';
 import { FrameworkDecisionAuthority } from '../pipeline/decisions/index.js';
 import { DiagnosticAccumulator } from '../pipeline/state/accumulators/diagnostic-accumulator.js';
 import { GateAccumulator } from '../pipeline/state/accumulators/gate-accumulator.js';
 import { McpToolRequestValidator } from '../validation/request-validator.js';
 
+import type { StateStoreOptions } from '#infra/database/stores/interface.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ToolResponse, McpToolRequest } from '#shared/types/index.js';
+import type { RequestIdentitySource } from '#shared/types/request-identity.js';
 import type {
   NamedInlineGate,
   ParsedCommand,
@@ -12,14 +15,12 @@ import type {
   ExecutionResults,
 } from './context-types.js';
 import type { InitializedScriptState, PipelineInternalState } from './internal-state.js';
-import type { StateStoreOptions } from '../../../infra/database/stores/interface.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type { ToolResponse, McpToolRequest } from '../../../shared/types/index.js';
-import type { RequestIdentitySource } from '../../../shared/types/request-identity.js';
 import type { FrameworkExecutionContext } from '../../frameworks/types/index.js';
 import type { ChainStepPrompt } from '../operators/types.js';
 import type { GateEnforcementAuthority } from '../pipeline/decisions/index.js';
 import type { ConvertedPrompt, ExecutionModifiers, ExecutionPlan } from '../types.js';
+
+import { noopLogger } from '#infra/logging/index.js';
 
 /**
  * Unified execution context that flows through the new pipeline

--- a/server/src/engine/execution/context/internal-state.ts
+++ b/server/src/engine/execution/context/internal-state.ts
@@ -4,8 +4,8 @@ import type {
   RequestIdentityContext,
   ScriptExecutionResult,
   ToolResponse,
-} from '../../../shared/types/index.js';
-import type { RequestIdentitySource } from '../../../shared/types/request-identity.js';
+} from '#shared/types/index.js';
+import type { RequestIdentitySource } from '#shared/types/request-identity.js';
 import type { PendingShellVerification, ShellVerifyResult } from '../../gates/shell/index.js';
 import type { GateEnforcementMode } from '../../gates/types.js';
 import type { InjectionState } from '../pipeline/decisions/injection/index.js';

--- a/server/src/engine/execution/delegation/strategy.ts
+++ b/server/src/engine/execution/delegation/strategy.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Client-specific delegation rendering strategies.
+import type { DelegationProfile } from '#shared/types/core-config.js';
+import type { RequestClientProfile } from '#shared/types/request-identity.js';
 import type { DelegationPayload } from './types.js';
-import type { DelegationProfile } from '../../../shared/types/core-config.js';
-import type { RequestClientProfile } from '../../../shared/types/request-identity.js';
 
 /** Client-specific rendering strategy for delegation CTAs. */
 export interface DelegationStrategy {

--- a/server/src/engine/execution/delegation/types.ts
+++ b/server/src/engine/execution/delegation/types.ts
@@ -6,7 +6,7 @@
  * into the DelegationRenderer. They are client-agnostic — the strategy
  * maps them to client-specific output.
  */
-import type { RequestClientProfile } from '../../../shared/types/request-identity.js';
+import type { RequestClientProfile } from '#shared/types/request-identity.js';
 
 /** Semantic delegation data (client-agnostic). */
 export interface DelegationPayload {

--- a/server/src/engine/execution/formatting/formatting-context.ts
+++ b/server/src/engine/execution/formatting/formatting-context.ts
@@ -1,5 +1,5 @@
 // @lifecycle canonical - Type guards and discriminated union for formatting contexts.
-import type { FormatterExecutionContext } from '../../../shared/types/chain-execution.js';
+import type { FormatterExecutionContext } from '#shared/types/chain-execution.js';
 import type { SessionContext } from '../context/index.js';
 
 /**

--- a/server/src/engine/execution/formatting/response-assembler.ts
+++ b/server/src/engine/execution/formatting/response-assembler.ts
@@ -4,12 +4,12 @@ import { DelegationRenderer } from '../delegation/renderer.js';
 import { getHandoffFooterInstruction } from '../delegation/strategy.js';
 import { PHASE_GUARD_GATE_ID } from '../pipeline/stages/09b-phase-guard-verification-stage.js';
 
+import type { GateReviewPrompt } from '#shared/types/chain-execution.js';
+import type { RequestClientProfile } from '#shared/types/request-identity.js';
 import type {
   ChainFormattingContext,
   SinglePromptFormattingContext,
 } from './formatting-context.js';
-import type { GateReviewPrompt } from '../../../shared/types/chain-execution.js';
-import type { RequestClientProfile } from '../../../shared/types/request-identity.js';
 import type { ExecutionContext } from '../context/index.js';
 import type { DelegationPayload, ExecutionEnvelope, RenderingHints } from '../delegation/types.js';
 import type { GateOperator } from '../parsers/types/operator-types.js';

--- a/server/src/engine/execution/operators/chain-operator-executor.ts
+++ b/server/src/engine/execution/operators/chain-operator-executor.ts
@@ -1,10 +1,11 @@
 // @lifecycle canonical - Executes chain operator steps within the pipeline.
-import { Logger } from '../../../infra/logging/index.js';
-import { processTemplate, processTemplateWithRefs } from '../../../shared/utils/jsonUtils.js';
 import { hasFrameworkGuidance } from '../../frameworks/utils/framework-detection.js';
 import { DEFAULT_GATE_RETRY_CONFIG } from '../../gates/constants.js';
 import { DelegationRenderer } from '../delegation/renderer.js';
 
+import type { PendingGateReview } from '#shared/types/chain-execution.js';
+import type { RequestClientProfile } from '#shared/types/request-identity.js';
+import type { ScriptReferenceResolverPort } from '#shared/utils/jsonUtils.js';
 import type {
   ChainStepExecutionInput,
   ChainStepPrompt,
@@ -12,13 +13,13 @@ import type {
   GateReviewInput,
   NormalStepInput,
 } from './types.js';
-import type { PendingGateReview } from '../../../shared/types/chain-execution.js';
-import type { RequestClientProfile } from '../../../shared/types/request-identity.js';
-import type { ScriptReferenceResolverPort } from '../../../shared/utils/jsonUtils.js';
 import type { DelegationPayload, RenderingHints } from '../delegation/types.js';
 import type { InjectionState } from '../pipeline/decisions/injection/types.js';
 import type { PromptReferenceResolver } from '../reference/index.js';
 import type { ConvertedPrompt } from '../types.js';
+
+import { Logger } from '#infra/logging/index.js';
+import { processTemplate, processTemplateWithRefs } from '#shared/utils/jsonUtils.js';
 
 /**
  * Type guard for gate review input

--- a/server/src/engine/execution/operators/types.ts
+++ b/server/src/engine/execution/operators/types.ts
@@ -1,5 +1,5 @@
 // @lifecycle canonical - Type definitions for chain operator execution
-import type { PendingGateReview } from '../../../shared/types/chain-execution.js';
+import type { PendingGateReview } from '#shared/types/chain-execution.js';
 import type { FrameworkExecutionContext } from '../../frameworks/types/index.js';
 import type { ConvertedPrompt, ExecutionPlan } from '../types.js';
 

--- a/server/src/engine/execution/parsers/argument-parser.ts
+++ b/server/src/engine/execution/parsers/argument-parser.ts
@@ -15,16 +15,17 @@
  */
 
 import { ArgumentSchemaValidator } from './argument-schema.js';
-import { Logger } from '../../../infra/logging/index.js';
+
+import type { PromptArgument } from '#shared/types/index.js';
+import type { ConvertedPrompt, ValidationResult } from '../types.js';
+
+import { Logger } from '#infra/logging/index.js';
 import {
   ArgumentValidationError,
   parseQuotedValue,
   safeJsonParse,
   validateJsonArguments,
-} from '../../../shared/utils/index.js';
-
-import type { PromptArgument } from '../../../shared/types/index.js';
-import type { ConvertedPrompt, ValidationResult } from '../types.js';
+} from '#shared/utils/index.js';
 
 type PromptDefinition = Pick<ConvertedPrompt, 'id' | 'arguments'>;
 

--- a/server/src/engine/execution/parsers/argument-schema.ts
+++ b/server/src/engine/execution/parsers/argument-schema.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Declares zod schemas for parsed operator arguments.
 import { z, type ZodTypeAny } from 'zod';
 
-import type { PromptArgument } from '../../../shared/types/index.js';
+import type { PromptArgument } from '#shared/types/index.js';
 import type { ConvertedPrompt } from '../types.js';
 
 export interface SchemaValidationIssue {

--- a/server/src/engine/execution/parsers/chain-blueprint-resolver.ts
+++ b/server/src/engine/execution/parsers/chain-blueprint-resolver.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Restores chain session blueprints for response-only execution.
-import type { Logger } from '../../../infra/logging/index.js';
-import type { ChainSessionService, SessionBlueprint } from '../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSessionService, SessionBlueprint } from '#shared/types/index.js';
 import type { ExecutionContext, ParsedCommand } from '../context/index.js';
 import type { ExecutionPlan } from '../types.js';
 

--- a/server/src/engine/execution/parsers/command-parser.ts
+++ b/server/src/engine/execution/parsers/command-parser.ts
@@ -15,8 +15,6 @@
 import { tokenizeCommand } from './command-tokenizer.js';
 import { normalizeSymbolicPrefixes } from './parser-utils.js';
 import { SymbolicCommandParser, createSymbolicCommandParser } from './symbolic-operator-parser.js';
-import { Logger } from '../../../infra/logging/index.js';
-import { PromptError, ValidationError, safeJsonParse } from '../../../shared/utils/index.js';
 
 import type { TokenizedCommand } from './command-tokenizer.js';
 import type { ConvertedPrompt, ExecutionModifier, ExecutionModifiers } from '../types.js';
@@ -26,6 +24,9 @@ import type {
   SymbolicCommandParseResult,
   SymbolicExecutionPlan,
 } from './types/operator-types.js';
+
+import { Logger } from '#infra/logging/index.js';
+import { PromptError, ValidationError, safeJsonParse } from '#shared/utils/index.js';
 
 export type CommandParseResult = CommandParseResultBase<
   OperatorDetectionResult,

--- a/server/src/engine/execution/parsers/index.ts
+++ b/server/src/engine/execution/parsers/index.ts
@@ -53,16 +53,17 @@ export {
 // Legacy parsing methods are preserved through deprecated redirects in consolidated-prompt-engine.ts
 
 // Re-export for convenience
-export type { PromptData } from '../../../shared/types/index.js';
-export type { PromptArgument } from '../../../shared/types/index.js';
+export type { PromptData } from '#shared/types/index.js';
+export type { PromptArgument } from '#shared/types/index.js';
 export type { ConvertedPrompt } from '../types.js';
 
 export type { ValidationResult, ValidationError, ValidationWarning } from '../types.js';
 
 import { ArgumentParser, createArgumentParser } from './argument-parser.js';
 import { UnifiedCommandParser, createUnifiedCommandParser } from './command-parser.js';
-import { Logger } from '../../../infra/logging/index.js';
 import { ContextResolver, createContextResolver } from '../context/context-resolver.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Complete parsing system with all components

--- a/server/src/engine/execution/parsers/symbolic-command-builder.ts
+++ b/server/src/engine/execution/parsers/symbolic-command-builder.ts
@@ -1,16 +1,17 @@
 // @lifecycle canonical - Builds ParsedCommand structures from symbolic operator parse results.
-import { PromptError } from '../../../shared/utils/index.js';
 
+import type { Logger } from '#infra/logging/index.js';
 import type {
   ExecutionContext as ArgumentExecutionContext,
   ArgumentParser,
 } from './argument-parser.js';
-import type { Logger } from '../../../infra/logging/index.js';
 import type { ShellVerifyGate } from '../../gates/shell/types.js';
 import type { ParsedCommand } from '../context/index.js';
 import type { ChainStepPrompt } from '../operators/types.js';
 import type { ConvertedPrompt } from '../types.js';
 import type { SymbolicCommandParseResult } from './types/operator-types.js';
+
+import { PromptError } from '#shared/utils/index.js';
 
 type ParsedArgumentsResult = {
   processedArgs: Record<string, any>;

--- a/server/src/engine/execution/parsers/symbolic-operator-parser.ts
+++ b/server/src/engine/execution/parsers/symbolic-operator-parser.ts
@@ -15,9 +15,10 @@ import {
   type SymbolicExecutionPlan,
   type SymbolicOperator,
 } from './types/operator-types.js';
-import { Logger } from '../../../infra/logging/index.js';
-import { ValidationError } from '../../../shared/utils/index.js';
 import { SHELL_VERIFY_DEFAULT_TIMEOUT } from '../../gates/constants.js';
+
+import { Logger } from '#infra/logging/index.js';
+import { ValidationError } from '#shared/utils/index.js';
 
 /**
  * Parser responsible for detecting and structuring symbolic command operators.

--- a/server/src/engine/execution/pipeline/decisions/framework/framework-decision-authority.ts
+++ b/server/src/engine/execution/pipeline/decisions/framework/framework-decision-authority.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Single source of truth for framework application decisions.
 
-import type { Logger } from '../../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { FrameworkDecision } from '../types.js';
 
 /**

--- a/server/src/engine/execution/pipeline/decisions/gates/gate-enforcement-authority.ts
+++ b/server/src/engine/execution/pipeline/decisions/gates/gate-enforcement-authority.ts
@@ -7,6 +7,8 @@ import {
 } from '../../../../gates/config/index.js';
 import { DEFAULT_RETRY_LIMIT } from '../../../../gates/constants.js';
 
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSessionService, GateReviewPrompt } from '#shared/types/index.js';
 import type {
   ActionResult,
   CreateReviewOptions,
@@ -21,8 +23,6 @@ import type {
   RetryConfig,
   VerdictSource,
 } from './gate-enforcement-types.js';
-import type { Logger } from '../../../../../infra/logging/index.js';
-import type { ChainSessionService, GateReviewPrompt } from '../../../../../shared/types/index.js';
 import type { GateDefinitionProvider } from '../../../../gates/core/gate-loader.js';
 import type { LightweightGateDefinition } from '../../../../gates/types.js';
 

--- a/server/src/engine/execution/pipeline/decisions/gates/gate-enforcement-types.ts
+++ b/server/src/engine/execution/pipeline/decisions/gates/gate-enforcement-types.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Type definitions for gate enforcement authority.
 
-import type { PendingGateReview } from '../../../../../shared/types/chain-execution.js';
+import type { PendingGateReview } from '#shared/types/chain-execution.js';
 import type { GateVerdictSource } from '../../../../gates/core/gate-verdict-contract.js';
 
 export type {

--- a/server/src/engine/execution/pipeline/decisions/injection/constants.ts
+++ b/server/src/engine/execution/pipeline/decisions/injection/constants.ts
@@ -17,4 +17,4 @@ export {
   INJECTION_TYPES,
   MODIFIER_EFFECTS,
   RESOLUTION_PRIORITY,
-} from '../../../../../shared/types/injection.js';
+} from '#shared/types/injection.js';

--- a/server/src/engine/execution/pipeline/decisions/injection/injection-decision-service.ts
+++ b/server/src/engine/execution/pipeline/decisions/injection/injection-decision-service.ts
@@ -8,6 +8,7 @@ import {
 } from './constants.js';
 import { ConditionEvaluator, HierarchyResolver } from './internal/index.js';
 
+import type { Logger } from '#infra/logging/index.js';
 import type {
   ExecutionContextType,
   InjectionConfig,
@@ -19,7 +20,6 @@ import type {
   InjectionTarget,
   InjectionType,
 } from './types.js';
-import type { Logger } from '../../../../../infra/logging/index.js';
 
 /**
  * Single source of truth for all injection decisions.

--- a/server/src/engine/execution/pipeline/decisions/injection/internal/condition-evaluator.ts
+++ b/server/src/engine/execution/pipeline/decisions/injection/internal/condition-evaluator.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Evaluates conditional injection rules.
 
-import type { Logger } from '../../../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type {
   InjectionCondition,
   InjectionConditionWhen,

--- a/server/src/engine/execution/pipeline/decisions/injection/internal/hierarchy-resolver.ts
+++ b/server/src/engine/execution/pipeline/decisions/injection/internal/hierarchy-resolver.ts
@@ -2,7 +2,7 @@
 
 import { DEFAULT_CONFIG_BY_TYPE, RESOLUTION_PRIORITY } from '../constants.js';
 
-import type { Logger } from '../../../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type {
   CategoryInjectionConfig,
   ChainInjectionConfig,

--- a/server/src/engine/execution/pipeline/decisions/injection/session-overrides.ts
+++ b/server/src/engine/execution/pipeline/decisions/injection/session-overrides.ts
@@ -1,12 +1,12 @@
 // @lifecycle canonical - Runtime session overrides for injection control.
 
+import type { Logger } from '#infra/logging/index.js';
 import type {
   InjectionRuntimeOverride,
   InjectionSessionState,
   InjectionTarget,
   InjectionType,
 } from './types.js';
-import type { Logger } from '../../../../../infra/logging/index.js';
 
 /**
  * Manages runtime session overrides for injection control.

--- a/server/src/engine/execution/pipeline/decisions/injection/types.ts
+++ b/server/src/engine/execution/pipeline/decisions/injection/types.ts
@@ -23,4 +23,4 @@ export type {
   PromptInjectionRule,
   ResolvedInjectionConfig,
   StepInjectionConfig,
-} from '../../../../../shared/types/injection.js';
+} from '#shared/types/injection.js';

--- a/server/src/engine/execution/pipeline/prompt-execution-pipeline.ts
+++ b/server/src/engine/execution/pipeline/prompt-execution-pipeline.ts
@@ -5,8 +5,7 @@ import { trace, SpanStatusCode, context as otelContext } from '@opentelemetry/ap
 
 import { ExecutionContext } from '../context/index.js';
 
-import type { PipelineStage } from './stage.js';
-import type { Logger } from '../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type {
   MetricsCollector,
   PipelineStageType,
@@ -18,7 +17,8 @@ import type {
   ToolResponse,
   HookRegistryPort,
   PipelineHookContext,
-} from '../../../shared/types/index.js';
+} from '#shared/types/index.js';
+import type { PipelineStage } from './stage.js';
 import type { Span } from '@opentelemetry/api';
 
 /**

--- a/server/src/engine/execution/pipeline/stage.ts
+++ b/server/src/engine/execution/pipeline/stage.ts
@@ -1,5 +1,5 @@
 // @lifecycle canonical - Base interface for execution pipeline stages.
-import type { Logger } from '../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { ExecutionContext } from '../context/index.js';
 
 /**

--- a/server/src/engine/execution/pipeline/stages/00-dependency-injection-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/00-dependency-injection-stage.ts
@@ -2,13 +2,13 @@
 import { GateEnforcementAuthority } from '../decisions/index.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type {
   ChainSessionService,
   HookRegistryPort,
   McpNotificationEmitterPort,
   MetricsCollector,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
 import type { GateDefinitionProvider } from '../../../gates/core/gate-loader.js';
 import type { TemporaryGateRegistry } from '../../../gates/core/temporary-gate-registry.js';
 import type { ExecutionContext } from '../../context/index.js';

--- a/server/src/engine/execution/pipeline/stages/00-execution-lifecycle-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/00-execution-lifecycle-stage.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { TemporaryGateRegistry } from '../../../gates/core/temporary-gate-registry.js';
 import type { ExecutionContext } from '../../context/index.js';
 import type { CleanupHandler } from '../../context/internal-state.js';

--- a/server/src/engine/execution/pipeline/stages/00-identity-resolution-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/00-identity-resolution-stage.ts
@@ -1,14 +1,15 @@
 // @lifecycle canonical - Resolves request identity from MCP SDK extra payload.
-import { resolveRequestIdentityContext } from '../../../../shared/utils/request-identity-resolver.js';
-import { resolveContinuityScopeId } from '../../../../shared/utils/request-identity-scope.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type {
   RequestClientProfileHint,
   RequestIdentityResolverOptions,
-} from '../../../../shared/utils/request-identity-resolver.js';
+} from '#shared/utils/request-identity-resolver.js';
 import type { ExecutionContext } from '../../context/index.js';
+
+import { resolveRequestIdentityContext } from '#shared/utils/request-identity-resolver.js';
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) {

--- a/server/src/engine/execution/pipeline/stages/00-request-normalization-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/00-request-normalization-stage.ts
@@ -1,12 +1,13 @@
 // @lifecycle canonical - Normalizes incoming execution requests before parsing.
-import { serializeOptionValue } from '../../../../shared/utils/index.js';
 import { McpToolRequestValidator } from '../../validation/request-validator.js';
 import { detectToolRoutingCommand } from '../routing/tool-routing.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ChainSessionRouterPort, ToolResponse } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSessionRouterPort, ToolResponse } from '#shared/types/index.js';
 import type { ExecutionContext } from '../../context/index.js';
+
+import { serializeOptionValue } from '#shared/utils/index.js';
 
 type ToolRouter = (
   targetTool: string,

--- a/server/src/engine/execution/pipeline/stages/01-parsing-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/01-parsing-stage.ts
@@ -1,8 +1,7 @@
 // @lifecycle canonical - Parses incoming commands into structured operators.
-import { PromptError } from '../../../../shared/utils/index.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 // ChainSessionService no longer needed — blueprint resolution delegated to ChainBlueprintResolver
 import type { ExecutionContext, ParsedCommand } from '../../context/index.js';
 import type { ChainStepPrompt } from '../../operators/types.js';
@@ -15,6 +14,8 @@ import type { UnifiedCommandParser } from '../../parsers/command-parser.js';
 import type { SymbolicCommandBuilder } from '../../parsers/symbolic-command-builder.js';
 import type { SymbolicCommandParseResult } from '../../parsers/types/operator-types.js';
 import type { ConvertedPrompt } from '../../types.js';
+
+import { PromptError } from '#shared/utils/index.js';
 
 /**
  * Provider function to get all converted prompts.

--- a/server/src/engine/execution/pipeline/stages/02-inline-gate-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/02-inline-gate-stage.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Evaluates inline gates before heavy execution work.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { InlineGateProcessor } from '../../../gates/services/inline-gate-processor.js';
 import type { ExecutionContext } from '../../context/index.js';
 

--- a/server/src/engine/execution/pipeline/stages/03-operator-validation-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/03-operator-validation-stage.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Validates operator metadata and arguments.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { FrameworkValidator } from '../../../frameworks/framework-validator.js';
 import type { ExecutionContext } from '../../context/index.js';
 import type { ChainStepPrompt } from '../../operators/types.js';

--- a/server/src/engine/execution/pipeline/stages/04-planning-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/04-planning-stage.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Creates execution plans and resolves dependencies.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { ExecutionContext } from '../../context/index.js';
 import type { ExecutionPlanner } from '../../planning/execution-planner.js';
 import type { ExecutionPlan } from '../../types.js';

--- a/server/src/engine/execution/pipeline/stages/04b-script-execution-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/04b-script-execution-stage.ts
@@ -24,7 +24,7 @@
 
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type {
   ToolTriggerFilterPort,
   ScriptExecutorPort,
@@ -33,7 +33,7 @@ import type {
   ScriptExecutionRequest,
   ScriptExecutionResult,
   ToolDetectionMatch,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
 import type { ExecutionContext } from '../../context/index.js';
 
 /**

--- a/server/src/engine/execution/pipeline/stages/04c-script-auto-execute-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/04c-script-auto-execute-stage.ts
@@ -20,8 +20,8 @@
 
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { ExecutionContext } from '../../context/index.js';
 
 /**

--- a/server/src/engine/execution/pipeline/stages/05-gate-enhancement-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/05-gate-enhancement-stage.ts
@@ -2,7 +2,7 @@
 import { inlineDefinitionCarriers } from '../../../gates/services/gate-enhancement-service.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { GateEnhancementService } from '../../../gates/services/gate-enhancement-service.js';
 import type { TemporaryGateRegistrar } from '../../../gates/services/temporary-gate-registrar.js';
 import type { GatesConfig } from '../../../gates/types.js';

--- a/server/src/engine/execution/pipeline/stages/06-framework-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/06-framework-stage.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Applies framework guidance to prompts.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { FrameworkManager } from '../../../frameworks/framework-manager.js';
 import type {
   FrameworkExecutionContext,

--- a/server/src/engine/execution/pipeline/stages/06a-judge-selection-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/06a-judge-selection-stage.ts
@@ -1,8 +1,8 @@
 // @lifecycle canonical - Implements two-phase client-driven judge selection for resource enhancement.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ConfigManager } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ConfigManager } from '#shared/types/index.js';
 import type { JudgeMenuFormatter } from '../../../gates/judge/judge-menu-formatter.js';
 import type { JudgeResourceCollector } from '../../../gates/judge/judge-resource-collector.js';
 import type { ExecutionContext } from '../../context/index.js';

--- a/server/src/engine/execution/pipeline/stages/06b-prompt-guidance-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/06b-prompt-guidance-stage.ts
@@ -1,8 +1,8 @@
 // @lifecycle canonical - Injects prompt guidance metadata into the execution context.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { StyleManagerPort } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { StyleManagerPort } from '#shared/types/index.js';
 import type {
   PromptGuidanceService,
   ServicePromptGuidanceResult,

--- a/server/src/engine/execution/pipeline/stages/07-session-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/07-session-stage.ts
@@ -3,12 +3,8 @@ import { randomUUID } from 'crypto';
 
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type {
-  ChainSession,
-  ChainSessionService,
-  SessionBlueprint,
-} from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSession, ChainSessionService, SessionBlueprint } from '#shared/types/index.js';
 import type { ExecutionContext, ParsedCommand, SessionContext } from '../../context/index.js';
 import type { ExecutionPlan } from '../../types.js';
 import type { CreateReviewOptions } from '../decisions/gates/gate-enforcement-types.js';

--- a/server/src/engine/execution/pipeline/stages/07b-injection-control-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/07b-injection-control-stage.ts
@@ -11,7 +11,7 @@ import {
 } from '../decisions/injection/index.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { ExecutionContext } from '../../context/index.js';
 
 type InjectionConfigProvider = () => InjectionConfig;

--- a/server/src/engine/execution/pipeline/stages/08-response-capture-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/08-response-capture-stage.ts
@@ -1,8 +1,8 @@
 // @lifecycle canonical - Captures model responses and lifecycle decisions.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ChainSessionService } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSessionService } from '#shared/types/index.js';
 import type { GateVerdictProcessor } from '../../../gates/services/gate-verdict-processor.js';
 import type { StepCaptureService } from '../../capture/step-capture-service.js';
 import type { ExecutionContext, SessionContext } from '../../context/index.js';

--- a/server/src/engine/execution/pipeline/stages/08b-shell-verification-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/08b-shell-verification-stage.ts
@@ -28,9 +28,9 @@ import {
 } from '../../../gates/shell/index.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { PendingShellVerificationSnapshot } from '../../../../shared/types/chain-execution.js';
-import type { ChainSessionService } from '../../../../shared/types/chain-session.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { PendingShellVerificationSnapshot } from '#shared/types/chain-execution.js';
+import type { ChainSessionService } from '#shared/types/chain-session.js';
 import type { ExecutionContext } from '../../context/index.js';
 
 /**

--- a/server/src/engine/execution/pipeline/stages/09-execution-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/09-execution-stage.ts
@@ -1,16 +1,17 @@
 // @lifecycle canonical - Runs operator executors and orchestrates outputs.
-import { processTemplateWithRefs } from '../../../../shared/utils/jsonUtils.js';
 import { hasFrameworkGuidance } from '../../../frameworks/utils/framework-detection.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ExecutionRecordStore } from '../../../../modules/chains/execution-record-store.js';
-import type { ChainSessionService } from '../../../../shared/types/index.js';
-import type { ScriptReferenceResolverPort } from '../../../../shared/utils/jsonUtils.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ExecutionRecordStore } from '#modules/chains/execution-record-store.js';
+import type { ChainSessionService } from '#shared/types/index.js';
+import type { ScriptReferenceResolverPort } from '#shared/utils/jsonUtils.js';
 import type { ExecutionContext } from '../../context/index.js';
 import type { ChainOperatorExecutor } from '../../operators/chain-operator-executor.js';
 import type { ChainStepRenderResult } from '../../operators/types.js';
 import type { PromptReferenceResolver } from '../../reference/prompt-reference-resolver.js';
+
+import { processTemplateWithRefs } from '#shared/utils/jsonUtils.js';
 
 /**
  * Pipeline Stage 9: Step Execution

--- a/server/src/engine/execution/pipeline/stages/09b-phase-guard-verification-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/09b-phase-guard-verification-stage.ts
@@ -25,9 +25,9 @@ import {
 } from '../../../frameworks/phase-guards/index.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ChainSessionService } from '../../../../shared/types/chain-session.js';
-import type { PhaseGuardsConfig } from '../../../../shared/types/core-config.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSessionService } from '#shared/types/chain-session.js';
+import type { PhaseGuardsConfig } from '#shared/types/core-config.js';
 import type { ProcessingStep, FrameworkGuide } from '../../../frameworks/types/framework-types.js';
 import type { ExecutionContext } from '../../context/index.js';
 

--- a/server/src/engine/execution/pipeline/stages/10-formatting-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/10-formatting-stage.ts
@@ -5,10 +5,10 @@ import {
 } from '../../formatting/formatting-context.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ExecutionRecordStore } from '../../../../modules/chains/execution-record-store.js';
-import type { FormatterExecutionContext } from '../../../../shared/types/chain-execution.js';
-import type { ResponseFormatterPort } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ExecutionRecordStore } from '#modules/chains/execution-record-store.js';
+import type { FormatterExecutionContext } from '#shared/types/chain-execution.js';
+import type { ResponseFormatterPort } from '#shared/types/index.js';
 import type { ExecutionContext } from '../../context/index.js';
 import type { SinglePromptFormattingContext } from '../../formatting/formatting-context.js';
 import type { ResponseAssembler } from '../../formatting/response-assembler.js';

--- a/server/src/engine/execution/pipeline/stages/10-gate-review-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/10-gate-review-stage.ts
@@ -4,9 +4,9 @@ import { runGateShellVerifications } from '../../../gates/services/gate-shell-ve
 import { formatGateShellVerifySection } from '../../../gates/shell/shell-verify-message-formatter.js';
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { GatesConfig } from '../../../../shared/types/core-config.js';
-import type { ChainSessionService } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { GatesConfig } from '#shared/types/core-config.js';
+import type { ChainSessionService } from '#shared/types/index.js';
 import type { GateDefinitionProvider } from '../../../gates/core/gate-loader.js';
 import type { ExecutionContext } from '../../context/index.js';
 import type { ChainOperatorExecutor } from '../../operators/chain-operator-executor.js';

--- a/server/src/engine/execution/pipeline/stages/12-post-formatting-cleanup-stage.ts
+++ b/server/src/engine/execution/pipeline/stages/12-post-formatting-cleanup-stage.ts
@@ -1,8 +1,8 @@
 // @lifecycle canonical - Cleans up formatting artifacts before returning output.
 import { BasePipelineStage } from '../stage.js';
 
-import type { Logger } from '../../../../infra/logging/index.js';
-import type { ChainSessionService, SessionBlueprint } from '../../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ChainSessionService, SessionBlueprint } from '#shared/types/index.js';
 import type { TemporaryGateRegistry } from '../../../gates/core/temporary-gate-registry.js';
 import type { ExecutionContext } from '../../context/index.js';
 

--- a/server/src/engine/execution/pipeline/state/accumulators/diagnostic-accumulator.ts
+++ b/server/src/engine/execution/pipeline/state/accumulators/diagnostic-accumulator.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Collects diagnostics from all pipeline stages.
 
-import type { Logger } from '../../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { DiagnosticEntry, DiagnosticLevelCounts } from '../types.js';
 
 /**

--- a/server/src/engine/execution/pipeline/state/accumulators/gate-accumulator.ts
+++ b/server/src/engine/execution/pipeline/state/accumulators/gate-accumulator.ts
@@ -2,7 +2,7 @@
 
 import { GATE_SOURCE_PRIORITY } from '../types.js';
 
-import type { Logger } from '../../../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { GateEntry, GateSource, GateSourceCounts } from '../types.js';
 
 /**

--- a/server/src/engine/execution/planning/category-extractor.ts
+++ b/server/src/engine/execution/planning/category-extractor.ts
@@ -10,7 +10,7 @@
  * Part of Gate System Intelligent Selection Upgrade -
  */
 
-import type { Logger } from '../../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 
 /**
  * Template gate configuration

--- a/server/src/engine/execution/planning/execution-planner.ts
+++ b/server/src/engine/execution/planning/execution-planner.ts
@@ -3,8 +3,8 @@ import { CategoryExtractor } from './category-extractor.js';
 import { GateSetResolver } from '../../gates/services/gate-set-resolver.js';
 import { isFrameworkInjected } from '../pipeline/decisions/injection/index.js';
 
-import type { Logger } from '../../../infra/logging/index.js';
-import type { ContentAnalysisResult, ContentAnalyzerPort } from '../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ContentAnalysisResult, ContentAnalyzerPort } from '#shared/types/index.js';
 import type { FrameworkManager } from '../../frameworks/framework-manager.js';
 import type { GateDefinitionProvider } from '../../gates/core/gate-loader.js';
 import type { GateManager } from '../../gates/gate-manager.js';
@@ -19,7 +19,7 @@ import type {
 } from '../types.js';
 
 type GateOverrideOptions = {
-  gates?: import('../../../shared/types/execution.js').GateSpecification[];
+  gates?: import('#shared/types/execution.js').GateSpecification[];
 };
 
 export interface ExecutionPlannerOptions {

--- a/server/src/engine/execution/reference/index.ts
+++ b/server/src/engine/execution/reference/index.ts
@@ -37,7 +37,7 @@
 
 // Core resolver
 export { PromptReferenceResolver } from './prompt-reference-resolver.js';
-export type { ToolDetectionServicePort, ScriptExecutorPort } from '../../../shared/types/index.js';
+export type { ToolDetectionServicePort, ScriptExecutorPort } from '#shared/types/index.js';
 
 // Creation-time validator
 export { PromptReferenceValidator } from './prompt-reference-validator.js';

--- a/server/src/engine/execution/reference/prompt-reference-resolver.ts
+++ b/server/src/engine/execution/reference/prompt-reference-resolver.ts
@@ -20,8 +20,15 @@ import {
   ScriptExecutionError,
 } from './errors.js';
 import { DEFAULT_RESOLUTION_OPTIONS } from './types.js';
-import { processTemplate } from '../../../shared/utils/jsonUtils.js';
 
+import type { Logger } from '#infra/logging/index.js';
+import type {
+  ScriptExecutorPort,
+  ToolDetectionServicePort,
+  LoadedScriptTool,
+  ScriptExecutionResult,
+  ToolDetectionMatch,
+} from '#shared/types/index.js';
 import type {
   DetectedReference,
   PreResolveResult,
@@ -29,15 +36,9 @@ import type {
   ReferenceResolutionResult,
   ResolutionDiagnostics,
 } from './types.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type {
-  ScriptExecutorPort,
-  ToolDetectionServicePort,
-  LoadedScriptTool,
-  ScriptExecutionResult,
-  ToolDetectionMatch,
-} from '../../../shared/types/index.js';
 import type { ConvertedPrompt } from '../types.js';
+
+import { processTemplate } from '#shared/utils/jsonUtils.js';
 
 /**
  * Regex pattern to match {{ref:prompt_id}} references.

--- a/server/src/engine/execution/reference/script-reference-resolver.ts
+++ b/server/src/engine/execution/reference/script-reference-resolver.ts
@@ -26,18 +26,18 @@ import {
 } from './script-reference-errors.js';
 import { DEFAULT_SCRIPT_RESOLUTION_OPTIONS } from './script-reference-types.js';
 
+import type { Logger } from '#infra/logging/index.js';
+import type {
+  ScriptExecutorPort,
+  LoadedScriptTool,
+  ScriptExecutionResult,
+} from '#shared/types/index.js';
 import type {
   DetectedScriptReference,
   ScriptPreResolveResult,
   ScriptResolutionDiagnostics,
   ScriptResolutionOptions,
 } from './script-reference-types.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type {
-  ScriptExecutorPort,
-  LoadedScriptTool,
-  ScriptExecutionResult,
-} from '../../../shared/types/index.js';
 
 /**
  * Regex pattern to match {{script:id}}, {{script:id.field}}, {{script:id args}} references.

--- a/server/src/engine/execution/reference/script-reference-types.ts
+++ b/server/src/engine/execution/reference/script-reference-types.ts
@@ -12,7 +12,7 @@
  * - {{script:analyzer key='value'}}     - Pass inline arguments
  */
 
-import type { ScriptExecutionResult } from '../../../shared/types/index.js';
+import type { ScriptExecutionResult } from '#shared/types/index.js';
 
 /**
  * Detected script reference in a template.

--- a/server/src/engine/execution/reference/types.ts
+++ b/server/src/engine/execution/reference/types.ts
@@ -7,7 +7,7 @@
  * other prompts by ID, with automatic script execution.
  */
 
-import type { ScriptExecutionResult, ToolDetectionMatch } from '../../../shared/types/index.js';
+import type { ScriptExecutionResult, ToolDetectionMatch } from '#shared/types/index.js';
 
 /**
  * Result of resolving a single prompt reference.

--- a/server/src/engine/execution/types.ts
+++ b/server/src/engine/execution/types.ts
@@ -6,7 +6,7 @@
  * This includes execution strategies, converted prompts, contexts, and chain execution.
  */
 
-import type { TemporaryGateInput } from '../../shared/types/execution.js';
+import type { TemporaryGateInput } from '#shared/types/execution.js';
 import type {
   ChainStep,
   ExecutionModifier,
@@ -17,7 +17,7 @@ import type {
   LoadedScriptTool,
   PromptArgument,
   PromptInjectionConfig,
-} from '../../shared/types/index.js';
+} from '#shared/types/index.js';
 
 // Re-exported for engine/ consumers. `CustomCheck`, `GateScope`, `GateSpecification` and
 // `ChainStep` were re-exported here too and had ZERO consumers via this path — dropped
@@ -344,4 +344,4 @@ export interface TemporaryGateDefinition {
 // `GateReviewPrompt` is defined in shared/types/chain-execution.ts and re-exported for the three
 // engine/ consumers that import it from here. `GateReviewExecutionContext` was re-exported
 // alongside it with ZERO consumers via this path — dropped 2026-07-29.
-export type { GateReviewPrompt } from '../../shared/types/chain-execution.js';
+export type { GateReviewPrompt } from '#shared/types/chain-execution.js';

--- a/server/src/engine/execution/validation/request-validator.ts
+++ b/server/src/engine/execution/validation/request-validator.ts
@@ -8,10 +8,11 @@
 import { ZodError } from 'zod';
 
 import { mcpToolRequestSchema } from './schemas.js';
-import { CHAIN_ID_PATTERN, recordParameterIssue } from '../../../shared/utils/index.js';
 import { isValidGateVerdict } from '../../gates/core/gate-verdict-contract.js';
 
-import type { McpToolRequest } from '../../../shared/types/execution.js';
+import type { McpToolRequest } from '#shared/types/execution.js';
+
+import { CHAIN_ID_PATTERN, recordParameterIssue } from '#shared/utils/index.js';
 
 /**
  * Validator for McpToolRequest with comprehensive error handling

--- a/server/src/engine/frameworks/definitions/framework-hot-reload.ts
+++ b/server/src/engine/frameworks/definitions/framework-hot-reload.ts
@@ -9,9 +9,9 @@
 import { createGenericGuide } from './generic-framework-guide.js';
 import { RuntimeFrameworkLoader } from './runtime-framework-loader.js';
 
+import type { Logger } from '#infra/logging/index.js';
+import type { HotReloadEvent } from '#shared/types/index.js';
 import type { FrameworkRegistry } from './registry.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type { HotReloadEvent } from '../../../shared/types/index.js';
 
 /**
  * Configuration for FrameworkHotReloadCoordinator

--- a/server/src/engine/frameworks/definitions/generic-framework-guide.ts
+++ b/server/src/engine/frameworks/definitions/generic-framework-guide.ts
@@ -41,8 +41,8 @@ import {
   convertProcessingSteps,
 } from '../utils/template-enhancer.js';
 
+import type { ContentAnalysisResult } from '#shared/types/index.js';
 import type { FrameworkResourceDefinition } from './framework-definition-types.js';
-import type { ContentAnalysisResult } from '../../../shared/types/index.js';
 import type { ConvertedPrompt, ExecutionType } from '../../execution/types.js';
 
 /**

--- a/server/src/engine/frameworks/definitions/registry.ts
+++ b/server/src/engine/frameworks/definitions/registry.ts
@@ -12,8 +12,9 @@ import {
   RuntimeFrameworkLoader,
   type RuntimeFrameworkLoaderConfig,
 } from './runtime-framework-loader.js';
-import { Logger } from '../../../infra/logging/index.js';
 import { FrameworkGuide } from '../types/index.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 // Data-driven framework system (YAML-only)
 

--- a/server/src/engine/frameworks/definitions/runtime-framework-loader.ts
+++ b/server/src/engine/frameworks/definitions/runtime-framework-loader.ts
@@ -21,13 +21,14 @@ import {
   validateFrameworkSchema,
   type FrameworkSchemaValidationResult,
 } from './framework-schema.js';
+
+import type { FrameworkResourceDefinition } from './framework-definition-types.js';
+
 import {
   loadYamlFileSync,
   discoverYamlDirectories,
   discoverNestedYamlDirectories,
-} from '../../../shared/utils/yaml/index.js';
-
-import type { FrameworkResourceDefinition } from './framework-definition-types.js';
+} from '#shared/utils/yaml/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/src/engine/frameworks/framework-manager.ts
+++ b/server/src/engine/frameworks/framework-manager.ts
@@ -20,10 +20,11 @@ import {
   FrameworkSelectionCriteria,
   FrameworkGuide,
 } from './types/index.js';
-import { Logger } from '../../infra/logging/index.js';
-import { BaseResourceHandler } from '../../shared/core/resource-manager/index.js';
 
 import type { ConvertedPrompt } from '../execution/types.js';
+
+import { Logger } from '#infra/logging/index.js';
+import { BaseResourceHandler } from '#shared/core/resource-manager/index.js';
 
 /**
  * Framework switch request (matches FrameworkStateStore interface)

--- a/server/src/engine/frameworks/framework-state-store.ts
+++ b/server/src/engine/frameworks/framework-state-store.ts
@@ -16,12 +16,13 @@ import {
   FrameworkExecutionContext,
   FrameworkSelectionCriteria,
 } from './types/index.js';
-import { SqliteEngine } from '../../infra/database/sqlite-engine.js';
-import { SqliteStateStore } from '../../infra/database/stores/sqlite-store.js';
-import { Logger } from '../../infra/logging/index.js';
-import { resolveContinuityScopeId } from '../../shared/utils/request-identity-scope.js';
 
-import type { StateStoreOptions } from '../../infra/database/stores/interface.js';
+import type { StateStoreOptions } from '#infra/database/stores/interface.js';
+
+import { SqliteEngine } from '#infra/database/sqlite-engine.js';
+import { SqliteStateStore } from '#infra/database/stores/sqlite-store.js';
+import { Logger } from '#infra/logging/index.js';
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 /**
  * Persisted framework state (saved to file)

--- a/server/src/engine/frameworks/framework-validator.ts
+++ b/server/src/engine/frameworks/framework-validator.ts
@@ -7,11 +7,11 @@
  * across parsing, execution, and state-management components. All lookups are
  * delegated to the FrameworkManager to ensure a single source of truth.
  */
-import { Logger } from '../../infra/logging/index.js';
-import { ValidationError, type ErrorContext } from '../../shared/utils/errorHandling.js';
-
 import type { FrameworkManager } from './framework-manager.js';
 import type { FrameworkDefinition } from './types/index.js';
+
+import { Logger } from '#infra/logging/index.js';
+import { ValidationError, type ErrorContext } from '#shared/utils/errorHandling.js';
 
 export interface FrameworkValidationOptions {
   /** Reject disabled frameworks when true */

--- a/server/src/engine/frameworks/integration/framework-semantic-integration.ts
+++ b/server/src/engine/frameworks/integration/framework-semantic-integration.ts
@@ -9,7 +9,6 @@
  * - Integration layer coordinates between systems WITHOUT interference
  */
 
-import { Logger } from '../../../infra/logging/index.js';
 import { FrameworkManager } from '../framework-manager.js';
 import { FrameworkStateStore } from '../framework-state-store.js';
 import { PromptGuidanceService } from '../prompt-guidance/service.js';
@@ -25,8 +24,10 @@ import {
   IntegratedAnalysisResult,
 } from '../types/index.js';
 
-import type { ContentAnalyzerPort, ContentAnalysisResult } from '../../../shared/types/index.js';
+import type { ContentAnalyzerPort, ContentAnalysisResult } from '#shared/types/index.js';
 import type { ConvertedPrompt } from '../../execution/types.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Integration types are sourced from the semantic integration type module

--- a/server/src/engine/frameworks/prompt-guidance/service.ts
+++ b/server/src/engine/frameworks/prompt-guidance/service.ts
@@ -7,7 +7,6 @@
  * Active framework state read from FrameworkManager (backed by SQLite via FrameworkStateStore).
  */
 
-import { Logger } from '../../../infra/logging/index.js';
 import { FrameworkManager } from '../framework-manager.js';
 import { TemplateEnhancer, createTemplateEnhancer } from './template-enhancer.js';
 import { TEMPLATE_VARIABLE_NAMES, substituteTemplateVariables } from './template-variables.js';
@@ -19,8 +18,10 @@ import {
   SystemPromptInjectionResult,
 } from '../types/index.js';
 
-import type { ContentAnalysisResult } from '../../../shared/types/index.js';
+import type { ContentAnalysisResult } from '#shared/types/index.js';
 import type { ConvertedPrompt } from '../../execution/types.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 export interface PromptGuidanceServiceConfig {
   systemPromptInjection: {

--- a/server/src/engine/frameworks/prompt-guidance/template-enhancer.ts
+++ b/server/src/engine/frameworks/prompt-guidance/template-enhancer.ts
@@ -9,9 +9,9 @@
  * - Modern: DYNAMIC injection of Markdown resources loaded by PromptAssetManager.
  */
 
-import { Logger } from '../../../infra/logging/index.js';
-
 import type { ConvertedPrompt } from '../../execution/types.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Template enhancement configuration

--- a/server/src/engine/frameworks/types/framework-types.ts
+++ b/server/src/engine/frameworks/types/framework-types.ts
@@ -7,7 +7,7 @@
  * sources to eliminate duplication.
  */
 
-import type { ContentAnalysisResult, ToolParameter } from '../../../shared/types/index.js';
+import type { ContentAnalysisResult, ToolParameter } from '#shared/types/index.js';
 import type { ConvertedPrompt, ExecutionType } from '../../execution/types.js';
 
 /**

--- a/server/src/engine/frameworks/types/semantic-integration-types.ts
+++ b/server/src/engine/frameworks/types/semantic-integration-types.ts
@@ -6,8 +6,8 @@
  * metadata used by the framework switching layer.
  */
 
+import type { ContentAnalysisResult } from '#shared/types/index.js';
 import type { FrameworkDefinition, FrameworkExecutionContext } from './framework-types.js';
-import type { ContentAnalysisResult } from '../../../shared/types/index.js';
 
 /**
  * Integrated analysis result combining semantic intelligence and framework

--- a/server/src/engine/frameworks/utils/step-generator.ts
+++ b/server/src/engine/frameworks/utils/step-generator.ts
@@ -7,7 +7,7 @@
  * to create step sequences and enhancements.
  */
 
-import type { ContentAnalysisResult } from '../../../shared/types/index.js';
+import type { ContentAnalysisResult } from '#shared/types/index.js';
 import type { PhaseGuard } from '../definitions/framework-schema.js';
 import type {
   ProcessingGuidance,

--- a/server/src/engine/gates/config/shell-preset-loader.ts
+++ b/server/src/engine/gates/config/shell-preset-loader.ts
@@ -17,7 +17,7 @@ import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-import { loadYamlFileSync } from '../../../shared/utils/yaml/index.js';
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/src/engine/gates/config/verdict-pattern-loader.ts
+++ b/server/src/engine/gates/config/verdict-pattern-loader.ts
@@ -18,7 +18,7 @@ import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
-import { loadYamlFileSync } from '../../../shared/utils/yaml/index.js';
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/src/engine/gates/core/gate-definition-loader.ts
+++ b/server/src/engine/gates/core/gate-definition-loader.ts
@@ -24,11 +24,12 @@ import {
   type GateSchemaValidationResult,
   type GateDefinitionYaml,
 } from './gate-schema.js';
+
 import {
   loadYamlFileSync,
   discoverYamlDirectories,
   discoverNestedYamlDirectories,
-} from '../../../shared/utils/yaml/index.js';
+} from '#shared/utils/yaml/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/src/engine/gates/core/gate-loader.ts
+++ b/server/src/engine/gates/core/gate-loader.ts
@@ -6,7 +6,6 @@
  */
 
 import { GateDefinitionLoader, type GateDefinitionLoaderConfig } from './gate-definition-loader.js';
-import { Logger } from '../../../infra/logging/index.js';
 import { isGateActiveForContext } from '../utils/gate-activation.js';
 
 import type {
@@ -15,6 +14,8 @@ import type {
   GateActivationResult,
 } from '../types.js';
 import type { TemporaryGateRegistry } from './temporary-gate-registry.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Minimal provider contract for loading gate definitions.

--- a/server/src/engine/gates/core/gate-validator.ts
+++ b/server/src/engine/gates/core/gate-validator.ts
@@ -22,7 +22,6 @@
  * - Retry hints generation
  */
 
-import { Logger } from '../../../infra/logging/index.js';
 import { getShellPreset } from '../config/index.js';
 import { getDefaultShellVerifyExecutor } from '../shell/shell-verify-executor.js';
 
@@ -36,6 +35,8 @@ import type {
   ValidationContext,
   GatePassCriteria,
 } from '../types.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Gate validation statistics
@@ -384,7 +385,7 @@ export class GateValidator {
     this.logger.debug(`[SCRIPT GATE] Executing script tool verification: ${toolId}`);
 
     try {
-      const { executeProcess } = await import('../../../shared/utils/process.js');
+      const { executeProcess } = await import('#shared/utils/process.js');
 
       const result = await executeProcess({
         command: toolId,

--- a/server/src/engine/gates/core/temporary-gate-registry.ts
+++ b/server/src/engine/gates/core/temporary-gate-registry.ts
@@ -6,9 +6,9 @@
  * Provides automatic cleanup, scope management, and integration with existing gate systems.
  */
 
-import { Logger } from '../../../infra/logging/index.js';
-
 import type { GateDefinition, GatePassCriteria, LightweightGateDefinition } from '../types.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Temporary gate definition with lifecycle management

--- a/server/src/engine/gates/gate-manager.ts
+++ b/server/src/engine/gates/gate-manager.ts
@@ -12,8 +12,6 @@
  */
 
 import { GateRegistry, createGateRegistry, type GateRegistryConfig } from './registry/index.js';
-import { Logger } from '../../infra/logging/index.js';
-import { BaseResourceHandler } from '../../shared/core/resource-manager/index.js';
 
 import type { GateStateStore } from './gate-state-store.js';
 import type {
@@ -25,6 +23,9 @@ import type {
   GateRegistryStats,
 } from './types/index.js';
 import type { IGateManager } from './types.js';
+
+import { Logger } from '#infra/logging/index.js';
+import { BaseResourceHandler } from '#shared/core/resource-manager/index.js';
 
 /**
  * Configuration for GateManager

--- a/server/src/engine/gates/gate-state-store.ts
+++ b/server/src/engine/gates/gate-state-store.ts
@@ -8,12 +8,12 @@
 
 import { EventEmitter } from 'events';
 
-import { SqliteEngine } from '../../infra/database/sqlite-engine.js';
-import { SqliteStateStore } from '../../infra/database/stores/sqlite-store.js';
-import { Logger } from '../../infra/logging/index.js';
-import { resolveContinuityScopeId } from '../../shared/utils/request-identity-scope.js';
+import type { StateStoreOptions } from '#infra/database/stores/interface.js';
 
-import type { StateStoreOptions } from '../../infra/database/stores/interface.js';
+import { SqliteEngine } from '#infra/database/sqlite-engine.js';
+import { SqliteStateStore } from '#infra/database/stores/sqlite-store.js';
+import { Logger } from '#infra/logging/index.js';
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 /**
  * Gate system state interface

--- a/server/src/engine/gates/guidance/GateGuidanceRenderer.ts
+++ b/server/src/engine/gates/guidance/GateGuidanceRenderer.ts
@@ -7,7 +7,7 @@
 
 import { filterFrameworkGuidance, hasFrameworkSpecificContent } from './FrameworkGuidanceFilter.js';
 
-import type { Logger } from '../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { GateContext } from '../core/gate-definitions.js';
 import type { GateDefinitionProvider } from '../core/gate-loader.js';
 import type { TemporaryGateRegistry } from '../core/temporary-gate-registry.js';

--- a/server/src/engine/gates/hot-reload/gate-hot-reload.ts
+++ b/server/src/engine/gates/hot-reload/gate-hot-reload.ts
@@ -11,7 +11,7 @@
 import { GateDefinitionLoader } from '../core/gate-definition-loader.js';
 import { createGenericGateGuide } from '../registry/generic-gate-guide.js';
 
-import type { Logger } from '../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { GateRegistry } from '../registry/gate-registry.js';
 import type {
   GateActivationRules,

--- a/server/src/engine/gates/judge/judge-menu-formatter.ts
+++ b/server/src/engine/gates/judge/judge-menu-formatter.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Formats resource menus and judge responses for Claude.
+import type { Logger } from '#infra/logging/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { ResourceMenu } from './judge-resource-collector.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type { ToolResponse } from '../../../shared/types/index.js';
 import type { ExecutionContext } from '../../execution/context/index.js';
 
 /** Narrow type for framework judge prompt data — avoids frameworks/ import. */

--- a/server/src/engine/gates/judge/judge-resource-collector.ts
+++ b/server/src/engine/gates/judge/judge-resource-collector.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Collects available resources (styles, frameworks, gates) for judge selection.
-import type { Logger } from '../../../infra/logging/index.js';
-import type { StyleManagerPort } from '../../../shared/types/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { StyleManagerPort } from '#shared/types/index.js';
 import type { ConvertedPrompt } from '../../execution/types.js';
 import type { GateDefinitionProvider } from '../../gates/core/gate-loader.js';
 import type { LightweightGateDefinition } from '../../gates/types.js';

--- a/server/src/engine/gates/registry/gate-registry.ts
+++ b/server/src/engine/gates/registry/gate-registry.ts
@@ -15,7 +15,6 @@
  */
 
 import { createGenericGateGuide } from './generic-gate-guide.js';
-import { Logger } from '../../../infra/logging/index.js';
 import {
   GateDefinitionLoader,
   type GateDefinitionLoaderConfig,
@@ -28,6 +27,8 @@ import type {
   GateGuideEntry,
   GateRegistryStats,
 } from '../types/index.js';
+
+import { Logger } from '#infra/logging/index.js';
 
 /**
  * Gate registry configuration

--- a/server/src/engine/gates/services/compositional-gate-service.ts
+++ b/server/src/engine/gates/services/compositional-gate-service.ts
@@ -1,10 +1,10 @@
 // @lifecycle canonical - Aggregates gate evaluations across configured services.
+import type { Logger } from '#infra/logging/index.js';
 import type {
   GateService,
   GateEnhancementResult,
   GateServiceConfig,
 } from './gate-service-interface.js';
-import type { Logger } from '../../../infra/logging/index.js';
 import type { ConvertedPrompt } from '../../execution/types.js';
 import type { GateContext } from '../core/gate-definitions.js';
 import type { GateGuidanceRenderer } from '../guidance/GateGuidanceRenderer.js';

--- a/server/src/engine/gates/services/gate-enhancement-service.ts
+++ b/server/src/engine/gates/services/gate-enhancement-service.ts
@@ -2,11 +2,11 @@
 import { GateSetResolver } from './gate-set-resolver.js';
 import { isFrameworkInjected } from '../../execution/pipeline/decisions/injection/index.js';
 
+import type { Logger } from '#infra/logging/index.js';
 import type { GateMetricsRecorder } from './gate-metrics-recorder.js';
 import type { GateService } from './gate-service-interface.js';
 import type { GateResolutionInput } from './gate-set-resolver.js';
 import type { RegisteredGateResult } from './temporary-gate-registrar.js';
-import type { Logger } from '../../../infra/logging/index.js';
 import type { ExecutionContext } from '../../execution/context/index.js';
 import type { ChainStepPrompt } from '../../execution/operators/types.js';
 import type { FrameworkDecisionInput } from '../../execution/pipeline/decisions/index.js';

--- a/server/src/engine/gates/services/gate-metrics-recorder.ts
+++ b/server/src/engine/gates/services/gate-metrics-recorder.ts
@@ -1,10 +1,10 @@
 // @lifecycle canonical - Records gate usage metrics for analytics.
-import type { GateValidationResult as ServiceGateValidationResult } from './gate-service-interface.js';
 import type {
   MetricsCollector,
   GateUsageMetric,
   GateValidationResult as MetricGateValidationResult,
-} from '../../../shared/types/index.js';
+} from '#shared/types/index.js';
+import type { GateValidationResult as ServiceGateValidationResult } from './gate-service-interface.js';
 import type { ExecutionContext } from '../../execution/context/index.js';
 
 /**

--- a/server/src/engine/gates/services/gate-service-factory.ts
+++ b/server/src/engine/gates/services/gate-service-factory.ts
@@ -2,9 +2,9 @@
 import { CompositionalGateService } from './compositional-gate-service.js';
 import { SemanticGateService } from './semantic-gate-service.js';
 
+import type { Logger } from '#infra/logging/index.js';
+import type { ConfigManager } from '#shared/types/index.js';
 import type { GateServiceConfig, GateService } from './gate-service-interface.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type { ConfigManager } from '../../../shared/types/index.js';
 import type { GateValidator } from '../core/gate-validator.js';
 import type { GateGuidanceRenderer } from '../guidance/GateGuidanceRenderer.js';
 

--- a/server/src/engine/gates/services/gate-set-resolver.ts
+++ b/server/src/engine/gates/services/gate-set-resolver.ts
@@ -2,7 +2,7 @@
 
 import { GATE_SOURCE_PRIORITY } from '../../execution/pipeline/state/types.js';
 
-import type { Logger } from '../../../infra/logging/index.js';
+import type { Logger } from '#infra/logging/index.js';
 import type { GateSource } from '../../execution/pipeline/state/types.js';
 import type { GateConfigurationInfo } from '../../execution/planning/category-extractor.js';
 import type { ConvertedPrompt, ExecutionModifiers } from '../../execution/types.js';

--- a/server/src/engine/gates/services/gate-verdict-processor.ts
+++ b/server/src/engine/gates/services/gate-verdict-processor.ts
@@ -1,10 +1,10 @@
 // @lifecycle canonical - Processes gate verdicts, actions, and hook events for chain sessions.
 import { parseGateVerdict } from '../core/gate-verdict-contract.js';
 
-import type { HookRegistry, HookExecutionContext } from '../../../infra/hooks/index.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type { McpNotificationEmitter } from '../../../infra/observability/notifications/index.js';
-import type { ChainSession, ChainSessionService } from '../../../shared/types/index.js';
+import type { HookRegistry, HookExecutionContext } from '#infra/hooks/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { McpNotificationEmitter } from '#infra/observability/notifications/index.js';
+import type { ChainSession, ChainSessionService } from '#shared/types/index.js';
 import type { ExecutionContext, SessionContext } from '../../execution/context/index.js';
 import type { GateAction } from '../../execution/pipeline/decisions/index.js';
 import type { ParsedGateVerdict } from '../core/gate-verdict-contract.js';

--- a/server/src/engine/gates/services/inline-gate-processor.ts
+++ b/server/src/engine/gates/services/inline-gate-processor.ts
@@ -3,9 +3,9 @@ import { formatCriteriaAsGuidance } from '../../execution/pipeline/criteria-guid
 import { loadShellPresets } from '../config/index.js';
 import { SHELL_VERIFY_DEFAULTS } from '../constants.js';
 
+import type { Logger } from '#infra/logging/index.js';
+import type { GateScope } from '#shared/types/execution.js';
 import type { GateReferenceResolver, GateReferenceResolution } from './gate-reference-resolver.js';
-import type { Logger } from '../../../infra/logging/index.js';
-import type { GateScope } from '../../../shared/types/execution.js';
 import type { ExecutionContext, ParsedCommand } from '../../execution/context/index.js';
 import type { ChainStepPrompt } from '../../execution/operators/types.js';
 import type { TemporaryGateRegistry } from '../core/temporary-gate-registry.js';

--- a/server/src/engine/gates/services/semantic-gate-service.ts
+++ b/server/src/engine/gates/services/semantic-gate-service.ts
@@ -1,13 +1,13 @@
 // @lifecycle migrating - Semantic scoring service still aligning with new guardrails.
 import { CompositionalGateService } from './compositional-gate-service.js';
 
+import type { Logger } from '#infra/logging/index.js';
 import type {
   GateService,
   GateEnhancementResult,
   GateServiceConfig,
   GateValidationResult,
 } from './gate-service-interface.js';
-import type { Logger } from '../../../infra/logging/index.js';
 import type { ConvertedPrompt } from '../../execution/types.js';
 import type { GateContext } from '../core/gate-definitions.js';
 import type { GateValidator } from '../core/gate-validator.js';

--- a/server/src/engine/gates/services/temporary-gate-registrar.ts
+++ b/server/src/engine/gates/services/temporary-gate-registrar.ts
@@ -2,9 +2,9 @@
 import { mergeGateBody } from './gate-body-merge.js';
 import { formatCriteriaAsGuidance } from '../../execution/pipeline/criteria-guidance.js';
 
+import type { Logger } from '#infra/logging/index.js';
 import type { GateBody } from './gate-body-merge.js';
 import type { GateReferenceResolver } from './gate-reference-resolver.js';
-import type { Logger } from '../../../infra/logging/index.js';
 import type { ExecutionContext } from '../../execution/context/index.js';
 import type { TemporaryGateInput } from '../../execution/types.js';
 import type {
@@ -94,7 +94,7 @@ export class TemporaryGateRegistrar {
 
     const overrides = context.state.gates.requestedOverrides as Record<string, any> | undefined;
     const normalizedGates = overrides?.['gates'] as
-      import('../../../shared/types/execution.js').GateSpecification[] | undefined;
+      import('#shared/types/execution.js').GateSpecification[] | undefined;
 
     const canonicalGateIds = new Set<string>();
     const resolvedGateIds = new Set<string>();

--- a/server/src/engine/gates/shell/git-checkpoint.ts
+++ b/server/src/engine/gates/shell/git-checkpoint.ts
@@ -2,7 +2,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
-import { Logger } from '../../../infra/logging/index.js';
+import { Logger } from '#infra/logging/index.js';
 
 const execAsync = promisify(exec);
 

--- a/server/src/engine/gates/shell/shell-verify-executor.ts
+++ b/server/src/engine/gates/shell/shell-verify-executor.ts
@@ -15,11 +15,12 @@
  * @see plans/ralph-style-loop.md for the implementation plan
  */
 
-import { executeProcess } from '../../../shared/utils/process.js';
 import { SHELL_VERIFY_DEFAULT_TIMEOUT, SHELL_VERIFY_MAX_TIMEOUT } from '../constants.js';
 import { SHELL_OUTPUT_MAX_CHARS } from './types.js';
 
 import type { ShellVerifyGate, ShellVerifyResult, ShellVerifyExecutorConfig } from './types.js';
+
+import { executeProcess } from '#shared/utils/process.js';
 
 /**
  * Shell Verification Executor

--- a/server/src/engine/gates/shell/shell-verify-message-formatter.ts
+++ b/server/src/engine/gates/shell/shell-verify-message-formatter.ts
@@ -9,9 +9,9 @@
  * Extracted from ShellVerificationStage to maintain orchestration layer limits.
  */
 
-import { resolveSignalName, resolveSignalDescription } from '../../../shared/utils/process.js';
-
 import type { ShellVerifyResult, PendingShellVerification } from './types.js';
+
+import { resolveSignalName, resolveSignalDescription } from '#shared/utils/process.js';
 
 /**
  * Gate-level shell verification result.

--- a/server/src/engine/gates/shell/verify-active-state-store.ts
+++ b/server/src/engine/gates/shell/verify-active-state-store.ts
@@ -21,8 +21,8 @@ import { DatabaseSync } from 'node:sqlite';
 
 import { SHELL_VERIFY_DEFAULT_MAX_ITERATIONS } from './types.js';
 
+import type { Logger } from '#infra/logging/index.js';
 import type { PendingShellVerification, VerifyActiveState } from './types.js';
-import type { Logger } from '../../../infra/logging/index.js';
 
 /**
  * Configuration for the state store.

--- a/server/src/engine/gates/utils/gate-definition-schema.ts
+++ b/server/src/engine/gates/utils/gate-definition-schema.ts
@@ -8,17 +8,14 @@
 
 import { z } from 'zod';
 
-import {
-  validateWithSchema,
-  type SchemaValidationResult,
-} from '../../../shared/utils/schema-validator.js';
-
 import type {
   GateDefinitionYaml,
   GatePassCriteria,
   GateRetryConfig,
   LightweightGateDefinition,
 } from '../types.js';
+
+import { validateWithSchema, type SchemaValidationResult } from '#shared/utils/schema-validator.js';
 
 const activationSchema = z
   .object({

--- a/server/src/infra/config/index.ts
+++ b/server/src/infra/config/index.ts
@@ -42,7 +42,7 @@ import {
   type InjectionConfig,
   type ConfigManager,
   type GatesConfig,
-} from '../../shared/types/index.js';
+} from '#shared/types/index.js';
 // Removed: ToolDescriptionLoader import to break circular dependency
 // Now injected via dependency injection pattern
 

--- a/server/src/infra/database/index.ts
+++ b/server/src/infra/database/index.ts
@@ -46,4 +46,4 @@ export {
   type SqliteStateStoreConfig,
   type StateStoreOptions,
 } from './stores/index.js';
-export type { DatabasePort } from '../../shared/types/persistence.js';
+export type { DatabasePort } from '#shared/types/persistence.js';

--- a/server/src/infra/database/resource-indexer.ts
+++ b/server/src/infra/database/resource-indexer.ts
@@ -33,11 +33,12 @@ import yaml from 'js-yaml';
 
 /** Injected tool loader — avoids direct import from modules layer. */
 export type ToolLoaderFn = (promptDir: string, promptId: string) => LoadedScriptTool[];
-import { computeContentHash } from '../../shared/utils/hash.js';
 
-import type { JSONSchemaDefinition, LoadedScriptTool } from '../../shared/types/automation.js';
-import type { DatabasePort, ToolIndexEntry } from '../../shared/types/persistence.js';
+import type { JSONSchemaDefinition, LoadedScriptTool } from '#shared/types/automation.js';
+import type { DatabasePort, ToolIndexEntry } from '#shared/types/persistence.js';
 import type { Logger } from '../logging/index.js';
+
+import { computeContentHash } from '#shared/utils/hash.js';
 
 /**
  * Resource types supported by the indexer
@@ -62,7 +63,7 @@ export interface IndexedResource {
 
 // ToolIndexEntry SSOT is in shared/types/persistence.ts (cross-layer contract).
 
-export type { ToolIndexEntry } from '../../shared/types/persistence.js';
+export type { ToolIndexEntry } from '#shared/types/persistence.js';
 
 /**
  * Sync result statistics

--- a/server/src/infra/database/sqlite-engine.ts
+++ b/server/src/infra/database/sqlite-engine.ts
@@ -26,7 +26,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
-import type { DatabasePort } from '../../shared/types/persistence.js';
+import type { DatabasePort } from '#shared/types/persistence.js';
 import type { Logger } from '../logging/index.js';
 
 /**

--- a/server/src/infra/database/stores/interface.ts
+++ b/server/src/infra/database/stores/interface.ts
@@ -6,7 +6,7 @@
  * and re-exported here for backward compatibility. SqliteStateStoreConfig is infra-specific.
  */
 
-export type { StateStoreOptions, StateStore } from '../../../shared/types/persistence.js';
+export type { StateStoreOptions, StateStore } from '#shared/types/persistence.js';
 
 /**
  * Options for creating a SQLite-based state store

--- a/server/src/infra/database/stores/sqlite-store.ts
+++ b/server/src/infra/database/stores/sqlite-store.ts
@@ -17,15 +17,11 @@
  * - Table schema is defined in SqliteEngine's embedded schema
  */
 
-import { resolveContinuityScopeId } from '../../../shared/utils/request-identity-scope.js';
-
+import type { DatabasePort, StateStore, StateStoreOptions } from '#shared/types/persistence.js';
 import type { SqliteStateStoreConfig } from './interface.js';
-import type {
-  DatabasePort,
-  StateStore,
-  StateStoreOptions,
-} from '../../../shared/types/persistence.js';
 import type { Logger } from '../../logging/index.js';
+
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 const DEFAULT_SCOPE_ID = 'default';
 

--- a/server/src/infra/hooks/hook-registry.ts
+++ b/server/src/infra/hooks/hook-registry.ts
@@ -14,7 +14,7 @@
 
 import { EventEmitter } from 'events';
 
-import type { GateDefinition, HookRegistryPort, Logger } from '../../shared/types/index.js';
+import type { GateDefinition, HookRegistryPort, Logger } from '#shared/types/index.js';
 
 /**
  * Minimal execution context for hook callbacks.

--- a/server/src/infra/http/index.ts
+++ b/server/src/infra/http/index.ts
@@ -10,7 +10,7 @@ import { ConfigLoader } from '../config/index.js';
 import { Logger } from '../logging/index.js';
 import { TransportRouter, createTransportRouter, TransportType } from './transport/index.js';
 
-import type { ApiRouterPort } from '../../shared/types/index.js';
+import type { ApiRouterPort } from '#shared/types/index.js';
 import type { Application } from 'express';
 
 // Re-export transport types and utilities for external consumers

--- a/server/src/infra/http/transport/index.ts
+++ b/server/src/infra/http/transport/index.ts
@@ -15,7 +15,7 @@ import express, { Request, Response } from 'express';
 import { ConfigLoader } from '../../config/index.js';
 import { Logger } from '../../logging/index.js';
 
-import type { TransportMode } from '../../../shared/types/index.js';
+import type { TransportMode } from '#shared/types/index.js';
 
 /**
  * Transport types supported by the server

--- a/server/src/infra/logging/index.ts
+++ b/server/src/infra/logging/index.ts
@@ -6,12 +6,13 @@
 
 import { appendFile, writeFile } from 'node:fs/promises';
 
-import { LogLevel, TransportType } from '../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
+
+import { LogLevel, TransportType } from '#shared/types/index.js';
 
 // Logger interface is defined in shared/types/ (Layer 0) for cross-layer access.
 // Re-exported here for backward compatibility.
-export type { Logger } from '../../shared/types/index.js';
-import type { Logger } from '../../shared/types/index.js';
+export type { Logger } from '#shared/types/index.js';
 
 /**
  * Log entry for the in-memory ring buffer (exposed via MCP resources)

--- a/server/src/infra/observability/metrics/analytics-service.ts
+++ b/server/src/infra/observability/metrics/analytics-service.ts
@@ -9,6 +9,8 @@
 
 import { EventEmitter } from 'events';
 
+import { Logger } from '../../logging/index.js';
+
 import {
   type MetricsCollector,
   type ExecutionData,
@@ -24,8 +26,7 @@ import {
   type PipelineStageMetric,
   type CommandExecutionMetric,
   type CommandExecutionMode,
-} from '../../../shared/types/metrics.js';
-import { Logger } from '../../logging/index.js';
+} from '#shared/types/metrics.js';
 
 /**
  * Centralized Metrics Collector

--- a/server/src/infra/observability/metrics/index.ts
+++ b/server/src/infra/observability/metrics/index.ts
@@ -31,4 +31,4 @@ export type {
   CommandExecutionMode,
   CommandExecutionMetric,
   MetricsCollector,
-} from '../../../shared/types/metrics.js';
+} from '#shared/types/metrics.js';

--- a/server/src/infra/observability/notifications/mcp-notification-emitter.ts
+++ b/server/src/infra/observability/notifications/mcp-notification-emitter.ts
@@ -16,7 +16,7 @@
  * - notifications/chain/failed - Chain failed with error
  */
 
-import type { McpNotificationEmitterPort } from '../../../shared/types/index.js';
+import type { McpNotificationEmitterPort } from '#shared/types/index.js';
 import type { Logger } from '../../logging/index.js';
 
 /**

--- a/server/src/infra/observability/telemetry/attribute-policy.ts
+++ b/server/src/infra/observability/telemetry/attribute-policy.ts
@@ -10,7 +10,7 @@
 
 import { EXCLUDED_ATTRIBUTES, SAFE_BUSINESS_ATTRIBUTES } from './types.js';
 
-import type { TelemetryAttributePolicy } from '../../../shared/types/index.js';
+import type { TelemetryAttributePolicy } from '#shared/types/index.js';
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
 
 // ===== Pure Functions =====

--- a/server/src/infra/observability/telemetry/hook-observer.ts
+++ b/server/src/infra/observability/telemetry/hook-observer.ts
@@ -21,8 +21,8 @@ import { trace, SpanStatusCode } from '@opentelemetry/api';
 import { AttributePolicyEnforcer } from './attribute-policy.js';
 import { TRACE_EVENTS } from './types.js';
 
+import type { Logger } from '#shared/types/index.js';
 import type { TelemetryRuntime } from './types.js';
-import type { Logger } from '../../../shared/types/index.js';
 import type {
   HookExecutionContext,
   GateEvaluationResult,

--- a/server/src/infra/observability/telemetry/runtime.ts
+++ b/server/src/infra/observability/telemetry/runtime.ts
@@ -19,8 +19,8 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 
+import type { Logger, TelemetryConfig } from '#shared/types/index.js';
 import type { TelemetryRuntime, TelemetryStatus } from './types.js';
-import type { Logger, TelemetryConfig } from '../../../shared/types/index.js';
 import type { Tracer } from '@opentelemetry/api';
 import type { Resource } from '@opentelemetry/resources';
 

--- a/server/src/infra/observability/tracking/resource-change-tracker.ts
+++ b/server/src/infra/observability/tracking/resource-change-tracker.ts
@@ -33,9 +33,9 @@ import { SqliteEngine } from '../../database/sqlite-engine.js';
 import { SqliteStateStore } from '../../database/stores/sqlite-store.js';
 import { Logger } from '../../logging/index.js';
 
-import type { ChangeSource, TrackedResourceType } from '../../../shared/types/index.js';
+import type { ChangeSource, TrackedResourceType } from '#shared/types/index.js';
 
-export type { ChangeSource, TrackedResourceType } from '../../../shared/types/index.js';
+export type { ChangeSource, TrackedResourceType } from '#shared/types/index.js';
 
 /**
  * Type of change operation

--- a/server/src/mcp/http/api.ts
+++ b/server/src/mcp/http/api.ts
@@ -10,13 +10,14 @@ import path from 'path';
 
 import express, { Request, Response } from 'express';
 
-import { PromptAssetManager } from '../../modules/prompts/index.js';
-import { reloadPromptData as reloadPromptDataFromDisk } from '../../modules/prompts/prompt-refresh-service.js';
 import { McpToolRouter } from '../tools/index.js';
 
-import type { Category, PromptData } from '../../modules/prompts/types.js';
-import type { ConfigManager, Logger, ToolResponse } from '../../shared/types/index.js';
+import type { Category, PromptData } from '#modules/prompts/types.js';
+import type { ConfigManager, Logger, ToolResponse } from '#shared/types/index.js';
 import type { ResourceManagerInput } from '../tools/resource-manager/core/types.js';
+
+import { PromptAssetManager } from '#modules/prompts/index.js';
+import { reloadPromptData as reloadPromptDataFromDisk } from '#modules/prompts/prompt-refresh-service.js';
 
 /**
  * API Manager class

--- a/server/src/mcp/metadata/definitions/prompt-engine.ts
+++ b/server/src/mcp/metadata/definitions/prompt-engine.ts
@@ -8,6 +8,7 @@ import {
   contractToParameterDescriptors,
 } from '../../contracts/schemas/adapter.js';
 
+import type { McpToolRequest } from '#shared/types/execution.js';
 import type {
   PromptEngineMetadataData,
   ToolMetadata,
@@ -15,7 +16,6 @@ import type {
   CommandDescriptor,
   UsagePatternDescriptor,
 } from './types.js';
-import type { McpToolRequest } from '../../../shared/types/execution.js';
 
 type RequestField = keyof McpToolRequest;
 

--- a/server/src/mcp/metadata/usage-tracker.ts
+++ b/server/src/mcp/metadata/usage-tracker.ts
@@ -3,4 +3,4 @@ export {
   recordActionInvocation,
   recordParameterIssue,
   getActionUsageSnapshot,
-} from '../../shared/utils/usage-tracker.js';
+} from '#shared/utils/usage-tracker.js';

--- a/server/src/mcp/tools/config-utils.ts
+++ b/server/src/mcp/tools/config-utils.ts
@@ -8,7 +8,7 @@
 
 import { access, copyFile, readFile, writeFile } from 'node:fs/promises';
 
-import { type ConfigManager, type Logger, Config } from '../../shared/types/index.js';
+import { type ConfigManager, type Logger, Config } from '#shared/types/index.js';
 
 export const CONFIG_VALID_KEYS = [
   'server.name',

--- a/server/src/mcp/tools/framework-manager/core/context.ts
+++ b/server/src/mcp/tools/framework-manager/core/context.ts
@@ -1,9 +1,9 @@
 // @lifecycle canonical - Shared context for framework resource services.
 
-import type { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import type { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import type { VersionHistoryService } from '../../../../modules/versioning/index.js';
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
+import type { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import type { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import type { VersionHistoryService } from '#modules/versioning/index.js';
+import type { ConfigManager, Logger } from '#shared/types/index.js';
 import type { ObjectDiffGenerator } from '../../resource-manager/prompt/analysis/object-diff-generator.js';
 import type { FrameworkFileWriter } from '../services/framework-file-writer.js';
 

--- a/server/src/mcp/tools/framework-manager/core/manager.ts
+++ b/server/src/mcp/tools/framework-manager/core/manager.ts
@@ -11,7 +11,6 @@
  * - FrameworkFileWriter: file I/O with merge support
  */
 
-import { VersionHistoryService } from '../../../../modules/versioning/index.js';
 import { ObjectDiffGenerator } from '../../resource-manager/prompt/analysis/object-diff-generator.js';
 import { FrameworkDiscoveryProcessor } from '../services/framework-discovery-processor.js';
 import { FrameworkDraftValidator } from '../services/framework-draft-validator.js';
@@ -19,10 +18,12 @@ import { FrameworkFileWriter } from '../services/framework-file-writer.js';
 import { FrameworkLifecycleProcessor } from '../services/framework-lifecycle-processor.js';
 import { FrameworkVersioningProcessor } from '../services/framework-versioning-processor.js';
 
+import type { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { FrameworkResourceContext } from './context.js';
 import type { FrameworkManagerInput, FrameworkManagerDependencies } from './types.js';
-import type { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import type { ToolResponse } from '../../../../shared/types/index.js';
+
+import { VersionHistoryService } from '#modules/versioning/index.js';
 
 export class FrameworkToolHandler {
   private readonly ctx: FrameworkResourceContext;
@@ -58,7 +59,7 @@ export class FrameworkToolHandler {
     deps.logger.debug('FrameworkToolHandler initialized');
   }
 
-  setDatabasePort(db: import('../../../../shared/types/persistence.js').DatabasePort): void {
+  setDatabasePort(db: import('#shared/types/persistence.js').DatabasePort): void {
     this.ctx.versionHistoryService.setDatabasePort(db);
   }
 

--- a/server/src/mcp/tools/framework-manager/core/types.ts
+++ b/server/src/mcp/tools/framework-manager/core/types.ts
@@ -3,9 +3,9 @@
  * Framework Manager Types
  */
 
-import type { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import type { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
+import type { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import type { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import type { ConfigManager, Logger } from '#shared/types/index.js';
 
 /**
  * Framework manager action identifiers

--- a/server/src/mcp/tools/framework-manager/services/framework-discovery-processor.ts
+++ b/server/src/mcp/tools/framework-manager/services/framework-discovery-processor.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Framework discovery operations: list, inspect.
 
+import type { ToolResponse } from '#shared/types/index.js';
 import type { FrameworkDraftValidator } from './framework-draft-validator.js';
-import type { ToolResponse } from '../../../../shared/types/index.js';
 import type { FrameworkResourceContext } from '../core/context.js';
 import type { FrameworkManagerInput } from '../core/types.js';
 

--- a/server/src/mcp/tools/framework-manager/services/framework-draft-validator.ts
+++ b/server/src/mcp/tools/framework-manager/services/framework-draft-validator.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Framework validation operations: scoring, error formatting, success formatting.
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { FrameworkCreationData, FrameworkDraftValidationResult } from '../core/types.js';
 
 export class FrameworkDraftValidator {

--- a/server/src/mcp/tools/framework-manager/services/framework-file-writer.ts
+++ b/server/src/mcp/tools/framework-manager/services/framework-file-writer.ts
@@ -10,16 +10,16 @@ import { existsSync } from 'fs';
 import { mkdir, readFile } from 'node:fs/promises';
 import { join } from 'path';
 
+import type { ConfigManager, Logger } from '#shared/types/index.js';
+import type { FrameworkCreationData } from '../core/types.js';
+
 import {
   ResourceMutationTransaction,
   ResourceVerificationService,
-} from '../../../../modules/resources/services/index.js';
-import { safeWriteFile } from '../../../../shared/utils/file-transactions.js';
-import { loadYamlFile } from '../../../../shared/utils/yaml/yaml-file-loader.js';
-import { serializeYaml } from '../../../../shared/utils/yaml/yaml-parser.js';
-
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
-import type { FrameworkCreationData } from '../core/types.js';
+} from '#modules/resources/services/index.js';
+import { safeWriteFile } from '#shared/utils/file-transactions.js';
+import { loadYamlFile } from '#shared/utils/yaml/yaml-file-loader.js';
+import { serializeYaml } from '#shared/utils/yaml/yaml-parser.js';
 
 // ============================================================================
 // Types

--- a/server/src/mcp/tools/framework-manager/services/framework-lifecycle-processor.ts
+++ b/server/src/mcp/tools/framework-manager/services/framework-lifecycle-processor.ts
@@ -6,8 +6,8 @@ import * as path from 'node:path';
 
 import { foldDeprecatedAuthoringKeys } from './framework-authoring-keys.js';
 
+import type { ToolResponse } from '#shared/types/index.js';
 import type { FrameworkDraftValidator } from './framework-draft-validator.js';
-import type { ToolResponse } from '../../../../shared/types/index.js';
 import type { FrameworkResourceContext } from '../core/context.js';
 import type { FrameworkManagerInput, FrameworkCreationData } from '../core/types.js';
 

--- a/server/src/mcp/tools/framework-manager/services/framework-versioning-processor.ts
+++ b/server/src/mcp/tools/framework-manager/services/framework-versioning-processor.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Framework versioning operations: history, rollback, compare.
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { FrameworkResourceContext } from '../core/context.js';
 import type { FrameworkManagerInput, FrameworkCreationData } from '../core/types.js';
 

--- a/server/src/mcp/tools/gate-manager/core/context.ts
+++ b/server/src/mcp/tools/gate-manager/core/context.ts
@@ -1,8 +1,8 @@
 // @lifecycle canonical - Shared context for gate resource services.
 
-import type { GateManager } from '../../../../engine/gates/gate-manager.js';
-import type { VersionHistoryService } from '../../../../modules/versioning/index.js';
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
+import type { GateManager } from '#engine/gates/gate-manager.js';
+import type { VersionHistoryService } from '#modules/versioning/index.js';
+import type { ConfigManager, Logger } from '#shared/types/index.js';
 import type { ObjectDiffGenerator } from '../../resource-manager/prompt/analysis/object-diff-generator.js';
 import type { GateFileWriter } from '../services/gate-file-writer.js';
 

--- a/server/src/mcp/tools/gate-manager/core/manager.ts
+++ b/server/src/mcp/tools/gate-manager/core/manager.ts
@@ -9,16 +9,17 @@
  * - GateVersioningProcessor: history, rollback, compare
  */
 
-import { VersionHistoryService } from '../../../../modules/versioning/index.js';
 import { ObjectDiffGenerator } from '../../resource-manager/prompt/analysis/object-diff-generator.js';
 import { GateDiscoveryProcessor } from '../services/gate-discovery-processor.js';
 import { GateFileWriter } from '../services/gate-file-writer.js';
 import { GateLifecycleProcessor } from '../services/gate-lifecycle-processor.js';
 import { GateVersioningProcessor } from '../services/gate-versioning-processor.js';
 
+import type { ToolResponse } from '#shared/types/index.js';
 import type { GateResourceContext } from './context.js';
 import type { GateManagerInput, GateManagerDependencies } from './types.js';
-import type { ToolResponse } from '../../../../shared/types/index.js';
+
+import { VersionHistoryService } from '#modules/versioning/index.js';
 
 export class GateToolHandler {
   private readonly lifecycle: GateLifecycleProcessor;
@@ -52,7 +53,7 @@ export class GateToolHandler {
     deps.logger.debug('GateToolHandler initialized');
   }
 
-  setDatabasePort(db: import('../../../../shared/types/persistence.js').DatabasePort): void {
+  setDatabasePort(db: import('#shared/types/persistence.js').DatabasePort): void {
     this.versionHistoryService.setDatabasePort(db);
   }
 

--- a/server/src/mcp/tools/gate-manager/core/types.ts
+++ b/server/src/mcp/tools/gate-manager/core/types.ts
@@ -3,8 +3,8 @@
  * Gate Manager Types
  */
 
-import type { GateManager } from '../../../../engine/gates/gate-manager.js';
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
+import type { GateManager } from '#engine/gates/gate-manager.js';
+import type { ConfigManager, Logger } from '#shared/types/index.js';
 
 /**
  * Gate manager action identifiers

--- a/server/src/mcp/tools/gate-manager/services/gate-discovery-processor.ts
+++ b/server/src/mcp/tools/gate-manager/services/gate-discovery-processor.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Gate read-only operations: list, inspect.
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { GateResourceContext } from '../core/context.js';
 import type { GateManagerInput } from '../core/types.js';
 

--- a/server/src/mcp/tools/gate-manager/services/gate-file-writer.ts
+++ b/server/src/mcp/tools/gate-manager/services/gate-file-writer.ts
@@ -2,15 +2,15 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
+import type { ConfigManager, Logger } from '#shared/types/index.js';
+import type { GateCreationData } from '../core/types.js';
+
 import {
   ResourceMutationTransaction,
   ResourceVerificationService,
   type ResourceVerificationFailurePayload,
-} from '../../../../modules/resources/services/index.js';
-import { serializeYaml } from '../../../../shared/utils/yaml/yaml-parser.js';
-
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
-import type { GateCreationData } from '../core/types.js';
+} from '#modules/resources/services/index.js';
+import { serializeYaml } from '#shared/utils/yaml/yaml-parser.js';
 
 export interface GateFileWriterDependencies {
   logger: Logger;

--- a/server/src/mcp/tools/gate-manager/services/gate-lifecycle-processor.ts
+++ b/server/src/mcp/tools/gate-manager/services/gate-lifecycle-processor.ts
@@ -3,11 +3,11 @@ import { existsSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { logMcpToolChange } from '../../../../runtime/resource-change-tracking.js';
-
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { GateResourceContext } from '../core/context.js';
 import type { GateManagerInput, GateCreationData } from '../core/types.js';
+
+import { logMcpToolChange } from '#runtime/resource-change-tracking.js';
 
 export class GateLifecycleProcessor {
   constructor(private readonly ctx: GateResourceContext) {}

--- a/server/src/mcp/tools/gate-manager/services/gate-versioning-processor.ts
+++ b/server/src/mcp/tools/gate-manager/services/gate-versioning-processor.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Gate versioning operations: history, rollback, compare.
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { GateResourceContext } from '../core/context.js';
 import type { GateManagerInput, GateCreationData } from '../core/types.js';
 

--- a/server/src/mcp/tools/index.ts
+++ b/server/src/mcp/tools/index.ts
@@ -40,22 +40,28 @@ import {
   createConsolidatedSystemControl,
 } from './system-control/index.js';
 import { ToolDescriptionLoader } from './tool-description-loader.js';
-import {
-  FrameworkManager,
-  createFrameworkManager,
-} from '../../engine/frameworks/framework-manager.js';
-import { FrameworkStateStore } from '../../engine/frameworks/framework-state-store.js';
+
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { GateManager } from '#engine/gates/gate-manager.js';
+import type { ChainSessionStore } from '#modules/chains/manager.js';
+import type { Category, PromptData } from '#modules/prompts/types.js';
+import type { GateSpecification } from '#shared/types/execution.js';
+import type { FrameworkManagerDependencies } from './framework-manager/core/types.js';
+import type { ResourceManagerInput } from './resource-manager/core/types.js';
+
+import { FrameworkManager, createFrameworkManager } from '#engine/frameworks/framework-manager.js';
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
 import {
   isValidGateVerdict,
   GATE_VERDICT_VALIDATION_MESSAGE,
-} from '../../engine/gates/core/gate-verdict-contract.js';
-import { GateStateStore, createGateStateStore } from '../../engine/gates/gate-state-store.js';
-import { PromptAssetManager } from '../../modules/prompts/index.js';
+} from '#engine/gates/core/gate-verdict-contract.js';
+import { GateStateStore, createGateStateStore } from '#engine/gates/gate-state-store.js';
+import { PromptAssetManager } from '#modules/prompts/index.js';
 // Gate evaluator removed - now using Framework validation
-import { createContentAnalyzer } from '../../modules/semantic/configurable-semantic-analyzer.js';
-import { createSemanticIntegrationFactory } from '../../modules/semantic/integrations/index.js';
-import { ConversationStore } from '../../modules/text-refs/conversation.js';
-import { TextReferenceStore } from '../../modules/text-refs/index.js';
+import { createContentAnalyzer } from '#modules/semantic/configurable-semantic-analyzer.js';
+import { createSemanticIntegrationFactory } from '#modules/semantic/integrations/index.js';
+import { ConversationStore } from '#modules/text-refs/conversation.js';
+import { TextReferenceStore } from '#modules/text-refs/index.js';
 import {
   type ConfigManager,
   type MetricsCollector,
@@ -63,16 +69,9 @@ import {
   type HookRegistryPort,
   type McpNotificationEmitterPort,
   ToolResponse,
-} from '../../shared/types/index.js';
+} from '#shared/types/index.js';
 // Schemas now hand-written in ./schemas/ (replaced generated mcp-schemas.ts)
 
-import type { FrameworkManagerDependencies } from './framework-manager/core/types.js';
-import type { ResourceManagerInput } from './resource-manager/core/types.js';
-import type { ConvertedPrompt } from '../../engine/execution/types.js';
-import type { GateManager } from '../../engine/gates/gate-manager.js';
-import type { ChainSessionStore } from '../../modules/chains/manager.js';
-import type { Category, PromptData } from '../../modules/prompts/types.js';
-import type { GateSpecification } from '../../shared/types/execution.js';
 // REMOVED: ExecutionCoordinator and ChainOrchestrator - modular chain system removed
 
 // Consolidated tools
@@ -276,7 +275,7 @@ export class McpToolRouter {
   /**
    * Set database port for persistence (cascades to all sub-handlers that need DB access).
    */
-  setDatabasePort(db: import('../../shared/types/persistence.js').DatabasePort): void {
+  setDatabasePort(db: import('#shared/types/persistence.js').DatabasePort): void {
     this.promptExecutor.setDatabasePort(db);
     this.promptResourceHandler.setDatabasePort(db);
     this.gateManagerTool.setDatabasePort(db);
@@ -513,7 +512,7 @@ export class McpToolRouter {
     | ((
         args: Record<string, unknown>,
         context: Record<string, unknown>
-      ) => Promise<import('../../shared/types/index.js').ToolResponse>)
+      ) => Promise<import('#shared/types/index.js').ToolResponse>)
     | null {
     const router = this.resourceManagerRouter;
     if (router == null) {

--- a/server/src/mcp/tools/prompt-engine/core/chain-session-router.ts
+++ b/server/src/mcp/tools/prompt-engine/core/chain-session-router.ts
@@ -1,16 +1,17 @@
 // @lifecycle canonical - Manages chain executions within the MCP prompt engine.
 import { ChainManagementCommand } from './types.js';
-import { LightweightGateSystem } from '../../../../engine/gates/core/index.js';
-import { ToolResponse } from '../../../../shared/types/index.js';
 import { ResponseFormatter } from '../processors/response-formatter.js';
 
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
 import type {
   ChainSession,
   ChainSessionService,
   ChainSessionRouterPort,
   StateStoreOptions,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
+
+import { LightweightGateSystem } from '#engine/gates/core/index.js';
+import { ToolResponse } from '#shared/types/index.js';
 
 /**
  * Detects whether an incoming command is a chain management operation.

--- a/server/src/mcp/tools/prompt-engine/core/pipeline-builder.ts
+++ b/server/src/mcp/tools/prompt-engine/core/pipeline-builder.ts
@@ -15,12 +15,12 @@
 
 import * as path from 'node:path';
 
-import { StepCaptureService } from '../../../../engine/execution/capture/step-capture-service.js';
-import { ResponseAssembler } from '../../../../engine/execution/formatting/response-assembler.js';
-import {
-  ChainBlueprintResolver,
-  SymbolicCommandBuilder,
-} from '../../../../engine/execution/parsers/index.js';
+import type { GateService } from '#engine/gates/services/gate-service-interface.js';
+import type { PipelineDependencies } from './pipeline-dependencies.js';
+
+import { StepCaptureService } from '#engine/execution/capture/step-capture-service.js';
+import { ResponseAssembler } from '#engine/execution/formatting/response-assembler.js';
+import { ChainBlueprintResolver, SymbolicCommandBuilder } from '#engine/execution/parsers/index.js';
 import {
   // Core pipeline
   PromptExecutionPipeline,
@@ -52,29 +52,26 @@ import {
   GateReviewStage,
   ResponseFormattingStage,
   PostFormattingCleanupStage,
-} from '../../../../engine/execution/pipeline/index.js';
-import { getDefaultRuntimeLoader } from '../../../../engine/frameworks/definitions/index.js';
+} from '#engine/execution/pipeline/index.js';
+import { getDefaultRuntimeLoader } from '#engine/frameworks/definitions/index.js';
 import {
   JudgeMenuFormatter,
   type FrameworkJudgePromptProvider,
-} from '../../../../engine/gates/judge/judge-menu-formatter.js';
-import { JudgeResourceCollector } from '../../../../engine/gates/judge/judge-resource-collector.js';
-import { GateEnhancementService } from '../../../../engine/gates/services/gate-enhancement-service.js';
-import { GateMetricsRecorder } from '../../../../engine/gates/services/gate-metrics-recorder.js';
-import { GateServiceFactory } from '../../../../engine/gates/services/gate-service-factory.js';
-import { GateVerdictProcessor } from '../../../../engine/gates/services/gate-verdict-processor.js';
-import { InlineGateProcessor } from '../../../../engine/gates/services/inline-gate-processor.js';
-import { TemporaryGateRegistrar } from '../../../../engine/gates/services/temporary-gate-registrar.js';
+} from '#engine/gates/judge/judge-menu-formatter.js';
+import { JudgeResourceCollector } from '#engine/gates/judge/judge-resource-collector.js';
+import { GateEnhancementService } from '#engine/gates/services/gate-enhancement-service.js';
+import { GateMetricsRecorder } from '#engine/gates/services/gate-metrics-recorder.js';
+import { GateServiceFactory } from '#engine/gates/services/gate-service-factory.js';
+import { GateVerdictProcessor } from '#engine/gates/services/gate-verdict-processor.js';
+import { InlineGateProcessor } from '#engine/gates/services/inline-gate-processor.js';
+import { TemporaryGateRegistrar } from '#engine/gates/services/temporary-gate-registrar.js';
 import {
   createShellVerifyExecutor,
   createVerifyActiveStateStore,
-} from '../../../../engine/gates/shell/index.js';
-import { createToolDetectionService } from '../../../../modules/automation/detection/tool-detection-service.js';
-import { createScriptExecutor } from '../../../../modules/automation/execution/script-executor.js';
-import { createToolTriggerFilter } from '../../../../modules/automation/execution/tool-trigger-filter.js';
-
-import type { PipelineDependencies } from './pipeline-dependencies.js';
-import type { GateService } from '../../../../engine/gates/services/gate-service-interface.js';
+} from '#engine/gates/shell/index.js';
+import { createToolDetectionService } from '#modules/automation/detection/tool-detection-service.js';
+import { createScriptExecutor } from '#modules/automation/execution/script-executor.js';
+import { createToolTriggerFilter } from '#modules/automation/execution/tool-trigger-filter.js';
 
 /**
  * Factory that constructs and wires the PromptExecutionPipeline.

--- a/server/src/mcp/tools/prompt-engine/core/pipeline-dependencies.ts
+++ b/server/src/mcp/tools/prompt-engine/core/pipeline-dependencies.ts
@@ -7,22 +7,21 @@
  * functions capture mutable state accessed during pipeline execution.
  */
 
-import type { ChainSessionRouter } from './chain-session-router.js';
-import type { ChainOperatorExecutor } from '../../../../engine/execution/operators/chain-operator-executor.js';
-import type { ParsingSystem } from '../../../../engine/execution/parsers/index.js';
-import type { ExecutionPlanner } from '../../../../engine/execution/planning/execution-planner.js';
-import type { PromptReferenceResolver } from '../../../../engine/execution/reference/prompt-reference-resolver.js';
-import type { ScriptReferenceResolver } from '../../../../engine/execution/reference/script-reference-resolver.js';
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
-import type { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import type { FrameworkValidator } from '../../../../engine/frameworks/framework-validator.js';
-import type { PromptGuidanceService } from '../../../../engine/frameworks/prompt-guidance/index.js';
-import type { LightweightGateSystem } from '../../../../engine/gates/core/index.js';
-import type { GateManager } from '../../../../engine/gates/gate-manager.js';
-import type { GateGuidanceRenderer } from '../../../../engine/gates/guidance/GateGuidanceRenderer.js';
-import type { GateReferenceResolver } from '../../../../engine/gates/services/gate-reference-resolver.js';
-import type { ExecutionRecordStore } from '../../../../modules/chains/execution-record-store.js';
-import type { StyleManager } from '../../../../modules/formatting/index.js';
+import type { ChainOperatorExecutor } from '#engine/execution/operators/chain-operator-executor.js';
+import type { ParsingSystem } from '#engine/execution/parsers/index.js';
+import type { ExecutionPlanner } from '#engine/execution/planning/execution-planner.js';
+import type { PromptReferenceResolver } from '#engine/execution/reference/prompt-reference-resolver.js';
+import type { ScriptReferenceResolver } from '#engine/execution/reference/script-reference-resolver.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import type { FrameworkValidator } from '#engine/frameworks/framework-validator.js';
+import type { PromptGuidanceService } from '#engine/frameworks/prompt-guidance/index.js';
+import type { LightweightGateSystem } from '#engine/gates/core/index.js';
+import type { GateManager } from '#engine/gates/gate-manager.js';
+import type { GateGuidanceRenderer } from '#engine/gates/guidance/GateGuidanceRenderer.js';
+import type { GateReferenceResolver } from '#engine/gates/services/gate-reference-resolver.js';
+import type { ExecutionRecordStore } from '#modules/chains/execution-record-store.js';
+import type { StyleManager } from '#modules/formatting/index.js';
 import type {
   Logger,
   MetricsCollector,
@@ -31,7 +30,8 @@ import type {
   ToolResponse,
   ConfigManager,
   ChainSessionService,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
+import type { ChainSessionRouter } from './chain-session-router.js';
 import type { ResponseFormatter } from '../processors/response-formatter.js';
 
 /** Narrow view of McpToolsManager consumed by PipelineBuilder. */

--- a/server/src/mcp/tools/prompt-engine/core/prompt-executor.ts
+++ b/server/src/mcp/tools/prompt-engine/core/prompt-executor.ts
@@ -17,45 +17,56 @@ import * as path from 'node:path';
 
 import { ChainSessionRouter } from './chain-session-router.js';
 import { PipelineBuilder } from './pipeline-builder.js';
-import { ChainOperatorExecutor } from '../../../../engine/execution/operators/chain-operator-executor.js';
-import { createParsingSystem } from '../../../../engine/execution/parsers/index.js';
-import { createSymbolicCommandParser } from '../../../../engine/execution/parsers/symbolic-operator-parser.js';
-import { ExecutionPlanner } from '../../../../engine/execution/planning/execution-planner.js';
+import { ToolDescriptionLoader } from '../../tool-description-loader.js';
+import { ResponseFormatter } from '../processors/response-formatter.js';
+import { renderPromptEngineGuide } from '../utils/guide.js';
+
+import type { ParsingSystem } from '#engine/execution/parsers/index.js';
+import type { PromptExecutionPipeline } from '#engine/execution/pipeline/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { GateManager } from '#engine/gates/gate-manager.js';
+import type { PromptData } from '#modules/prompts/types.js';
+import type { McpToolRequest } from '#shared/types/execution.js';
+
+import { ChainOperatorExecutor } from '#engine/execution/operators/chain-operator-executor.js';
+import { createParsingSystem } from '#engine/execution/parsers/index.js';
+import { createSymbolicCommandParser } from '#engine/execution/parsers/symbolic-operator-parser.js';
+import { ExecutionPlanner } from '#engine/execution/planning/execution-planner.js';
 import {
   PromptReferenceResolver,
   ScriptReferenceResolver,
-} from '../../../../engine/execution/reference/index.js';
-import { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import { FrameworkValidator } from '../../../../engine/frameworks/framework-validator.js';
+} from '#engine/execution/reference/index.js';
+import { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import { FrameworkValidator } from '#engine/frameworks/framework-validator.js';
 import {
   PromptGuidanceService,
   createPromptGuidanceService,
-} from '../../../../engine/frameworks/prompt-guidance/index.js';
-import { FrameworkExecutionContext } from '../../../../engine/frameworks/types/index.js';
+} from '#engine/frameworks/prompt-guidance/index.js';
+import { FrameworkExecutionContext } from '#engine/frameworks/types/index.js';
 import {
   LightweightGateSystem,
   createGateValidator,
   createTemporaryGateRegistry,
-} from '../../../../engine/gates/core/index.js';
+} from '#engine/gates/core/index.js';
 import {
   GateGuidanceRenderer,
   createGateGuidanceRenderer,
-} from '../../../../engine/gates/guidance/GateGuidanceRenderer.js';
-import { GateManagerProvider } from '../../../../engine/gates/registry/gate-provider-adapter.js';
-import { GateReferenceResolver } from '../../../../engine/gates/services/gate-reference-resolver.js';
-import { WorkspaceScriptLoader } from '../../../../modules/automation/core/index.js';
-import { createScriptExecutor } from '../../../../modules/automation/execution/script-executor.js';
+} from '#engine/gates/guidance/GateGuidanceRenderer.js';
+import { GateManagerProvider } from '#engine/gates/registry/gate-provider-adapter.js';
+import { GateReferenceResolver } from '#engine/gates/services/gate-reference-resolver.js';
+import { WorkspaceScriptLoader } from '#modules/automation/core/index.js';
+import { createScriptExecutor } from '#modules/automation/execution/script-executor.js';
 import {
   ExecutionRecordStore,
   createExecutionRecordStore,
-} from '../../../../modules/chains/execution-record-store.js';
-import { createChainSessionStore } from '../../../../modules/chains/manager.js';
-import { StyleManager, createStyleManager } from '../../../../modules/formatting/index.js';
-import { PromptAssetManager } from '../../../../modules/prompts/index.js';
-import { ContentAnalyzer } from '../../../../modules/semantic/configurable-semantic-analyzer.js';
-import { ConversationStore } from '../../../../modules/text-refs/conversation.js';
-import { TextReferenceStore, ArgumentHistoryTracker } from '../../../../modules/text-refs/index.js';
+} from '#modules/chains/execution-record-store.js';
+import { createChainSessionStore } from '#modules/chains/manager.js';
+import { StyleManager, createStyleManager } from '#modules/formatting/index.js';
+import { PromptAssetManager } from '#modules/prompts/index.js';
+import { ContentAnalyzer } from '#modules/semantic/configurable-semantic-analyzer.js';
+import { ConversationStore } from '#modules/text-refs/conversation.js';
+import { TextReferenceStore, ArgumentHistoryTracker } from '#modules/text-refs/index.js';
 import {
   type Logger,
   type MetricsCollector,
@@ -64,18 +75,8 @@ import {
   ToolResponse,
   ConfigManager,
   ChainSessionService,
-} from '../../../../shared/types/index.js';
-import { CHAIN_ID_PATTERN } from '../../../../shared/utils/index.js';
-import { ToolDescriptionLoader } from '../../tool-description-loader.js';
-import { ResponseFormatter } from '../processors/response-formatter.js';
-import { renderPromptEngineGuide } from '../utils/guide.js';
-
-import type { ParsingSystem } from '../../../../engine/execution/parsers/index.js';
-import type { PromptExecutionPipeline } from '../../../../engine/execution/pipeline/index.js';
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
-import type { GateManager } from '../../../../engine/gates/gate-manager.js';
-import type { PromptData } from '../../../../modules/prompts/types.js';
-import type { McpToolRequest } from '../../../../shared/types/execution.js';
+} from '#shared/types/index.js';
+import { CHAIN_ID_PATTERN } from '#shared/utils/index.js';
 
 export class PromptExecutor {
   public readonly inlineGateParser: ReturnType<typeof createSymbolicCommandParser>;
@@ -293,7 +294,7 @@ export class PromptExecutor {
     this.analyticsService = analyticsService;
   }
 
-  setDatabasePort(db: import('../../../../shared/types/persistence.js').DatabasePort): void {
+  setDatabasePort(db: import('#shared/types/persistence.js').DatabasePort): void {
     this.argumentHistoryTracker.setDatabasePort(db);
     if ('setDatabasePort' in this.chainSessionStore) {
       (this.chainSessionStore as { setDatabasePort(db: unknown): void }).setDatabasePort(db);
@@ -384,7 +385,7 @@ export class PromptExecutor {
       gate_action?: 'retry' | 'skip' | 'abort';
       user_response?: string;
       /** Unified gate specifications (canonical in v3.0.0+). Accepts gate IDs, simple checks, or full definitions. */
-      gates?: import('../../../../shared/types/execution.js').GateSpecification[];
+      gates?: import('#shared/types/execution.js').GateSpecification[];
       options?: Record<string, unknown>;
     },
     extra: any

--- a/server/src/mcp/tools/prompt-engine/core/types.ts
+++ b/server/src/mcp/tools/prompt-engine/core/types.ts
@@ -10,8 +10,8 @@
  * and are re-exported here for backward compatibility within the mcp/ layer.
  */
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
+import type { ToolResponse } from '#shared/types/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
 // Re-export cross-cutting types from shared/ (canonical location)
 export {
   type StepMetadata,
@@ -21,9 +21,9 @@ export {
   type PendingGateReview,
   type FormatterExecutionContext,
   type ChainState,
-} from '../../../../shared/types/chain-execution.js';
+} from '#shared/types/chain-execution.js';
 
-import type { FormatterExecutionContext } from '../../../../shared/types/chain-execution.js';
+import type { FormatterExecutionContext } from '#shared/types/chain-execution.js';
 
 /**
  * Chain step execution context

--- a/server/src/mcp/tools/prompt-engine/processors/response-formatter.ts
+++ b/server/src/mcp/tools/prompt-engine/processors/response-formatter.ts
@@ -13,7 +13,7 @@ import type {
   GateValidationInfo,
   ToolResponse,
   ResponseFormatterPort,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
 
 const fallbackLogger: Logger = {
   info: () => {},

--- a/server/src/mcp/tools/prompt-engine/utils/category-extractor.ts
+++ b/server/src/mcp/tools/prompt-engine/utils/category-extractor.ts
@@ -4,4 +4,4 @@ export {
   extractPromptCategory,
   type GateConfigurationInfo,
   type CategoryExtractionResult,
-} from '../../../../engine/execution/planning/category-extractor.js';
+} from '#engine/execution/planning/category-extractor.js';

--- a/server/src/mcp/tools/prompt-engine/utils/classification.ts
+++ b/server/src/mcp/tools/prompt-engine/utils/classification.ts
@@ -6,12 +6,13 @@
  * classification capabilities with clear separation of concerns.
  */
 
-import { ContentAnalyzer } from '../../../../modules/semantic/configurable-semantic-analyzer.js';
-import { isChainPrompt } from '../../../../shared/utils/chainUtils.js';
 import { PromptClassification } from '../core/types.js';
 
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
-import type { Logger } from '../../../../shared/types/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { Logger } from '#shared/types/index.js';
+
+import { ContentAnalyzer } from '#modules/semantic/configurable-semantic-analyzer.js';
+import { isChainPrompt } from '#shared/utils/chainUtils.js';
 
 const noopLogger: Logger = {
   info: () => {},

--- a/server/src/mcp/tools/prompt-engine/utils/context-builder.ts
+++ b/server/src/mcp/tools/prompt-engine/utils/context-builder.ts
@@ -6,13 +6,13 @@
  * context building capabilities with clear separation of concerns.
  */
 
-import { ExecutionContext } from '../../../../engine/execution/parsers/index.js';
-import { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import { FrameworkExecutionContext } from '../../../../engine/frameworks/types/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { Logger } from '#shared/types/index.js';
 
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
-import type { Logger } from '../../../../shared/types/index.js';
+import { ExecutionContext } from '#engine/execution/parsers/index.js';
+import { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import { FrameworkExecutionContext } from '#engine/frameworks/types/index.js';
 
 const noopLogger: Logger = {
   info: () => {},

--- a/server/src/mcp/tools/prompt-engine/utils/tool-routing.ts
+++ b/server/src/mcp/tools/prompt-engine/utils/tool-routing.ts
@@ -2,4 +2,4 @@
 export {
   detectToolRoutingCommand,
   type ToolRoutingResult,
-} from '../../../../engine/execution/pipeline/routing/tool-routing.js';
+} from '#engine/execution/pipeline/routing/tool-routing.js';

--- a/server/src/mcp/tools/prompt-engine/utils/validation.ts
+++ b/server/src/mcp/tools/prompt-engine/utils/validation.ts
@@ -6,10 +6,10 @@
  * validation capabilities with clear separation of concerns.
  */
 
-import { LightweightGateSystem } from '../../../../engine/gates/core/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { Logger } from '#shared/types/index.js';
 
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
-import type { Logger } from '../../../../shared/types/index.js';
+import { LightweightGateSystem } from '#engine/gates/core/index.js';
 
 const noopLogger: Logger = {
   info: () => {},

--- a/server/src/mcp/tools/resource-manager/checkpoint/manager.ts
+++ b/server/src/mcp/tools/resource-manager/checkpoint/manager.ts
@@ -16,18 +16,15 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import {
-  GitCheckpoint,
-  createGitCheckpoint,
-} from '../../../../engine/gates/shell/git-checkpoint.js';
-
+import type { ConfigManager, Logger, ToolResponse } from '#shared/types/index.js';
 import type {
   CheckpointManagerInput,
   CheckpointManagerDependencies,
   CheckpointRef,
   CheckpointState,
 } from './types.js';
-import type { ConfigManager, Logger, ToolResponse } from '../../../../shared/types/index.js';
+
+import { GitCheckpoint, createGitCheckpoint } from '#engine/gates/shell/git-checkpoint.js';
 
 /**
  * Create a fresh empty checkpoint state.

--- a/server/src/mcp/tools/resource-manager/checkpoint/types.ts
+++ b/server/src/mcp/tools/resource-manager/checkpoint/types.ts
@@ -6,7 +6,7 @@
  * Provides git-based checkpoint/rollback functionality for safe verification.
  */
 
-import type { ConfigManager, Logger } from '../../../../shared/types/index.js';
+import type { ConfigManager, Logger } from '#shared/types/index.js';
 
 /**
  * Checkpoint actions - simplified compared to other resource types

--- a/server/src/mcp/tools/resource-manager/core/router.ts
+++ b/server/src/mcp/tools/resource-manager/core/router.ts
@@ -7,9 +7,8 @@
  */
 
 import { PROMPT_ONLY_ACTIONS, FRAMEWORK_ONLY_ACTIONS, CHECKPOINT_ONLY_ACTIONS } from './types.js';
-import { resolveRequestIdentity } from '../../../../shared/utils/request-identity-resolver.js';
-import { resolveContinuityScopeId } from '../../../../shared/utils/request-identity-scope.js';
 
+import type { Logger, ToolResponse } from '#shared/types/index.js';
 import type {
   ResourceManagerInput,
   ResourceManagerDependencies,
@@ -18,7 +17,6 @@ import type {
   ResourceAction,
   ActionValidationResult,
 } from './types.js';
-import type { Logger, ToolResponse } from '../../../../shared/types/index.js';
 import type { PromptResourceActionId } from '../../../metadata/definitions/prompt-resource.js';
 import type {
   FrameworkManagerActionId,
@@ -29,6 +27,9 @@ import type { GateManagerActionId, GateManagerInput } from '../../gate-manager/c
 import type { GateToolHandler } from '../../gate-manager/index.js';
 import type { CheckpointToolHandler } from '../checkpoint/index.js';
 import type { CheckpointManagerInput, CheckpointAction } from '../checkpoint/types.js';
+
+import { resolveRequestIdentity } from '#shared/utils/request-identity-resolver.js';
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 /**
  * ResourceManagerRouter routes requests to the appropriate handler

--- a/server/src/mcp/tools/resource-manager/core/types.ts
+++ b/server/src/mcp/tools/resource-manager/core/types.ts
@@ -6,7 +6,7 @@
  * that routes to prompt, gate, and framework handlers.
  */
 
-import type { Logger, ToolResponse } from '../../../../shared/types/index.js';
+import type { Logger, ToolResponse } from '#shared/types/index.js';
 import type {
   FrameworkManagerInput,
   FrameworkGate,

--- a/server/src/mcp/tools/resource-manager/prompt/analysis/comparison-engine.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/analysis/comparison-engine.ts
@@ -5,7 +5,7 @@
 
 import { PromptClassification } from '../core/types.js';
 
-import type { Logger } from '../../../../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 
 /**
  * Comparison result interface

--- a/server/src/mcp/tools/resource-manager/prompt/analysis/gate-analyzer.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/analysis/gate-analyzer.ts
@@ -6,11 +6,8 @@
  * Integrates with the temporary gate system to provide intelligent gate recommendations.
  */
 
-import type {
-  ConvertedPrompt,
-  TemporaryGateDefinition,
-} from '../../../../../engine/execution/types.js';
-import type { Logger } from '../../../../../shared/types/index.js';
+import type { ConvertedPrompt, TemporaryGateDefinition } from '#engine/execution/types.js';
+import type { Logger } from '#shared/types/index.js';
 import type { PromptResourceDependencies } from '../core/types.js';
 
 /**

--- a/server/src/mcp/tools/resource-manager/prompt/analysis/object-diff-generator.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/analysis/object-diff-generator.ts
@@ -2,9 +2,9 @@
 
 import { createPatch, structuredPatch } from 'diff';
 
-import { serializeYaml } from '../../../../../shared/utils/yaml/yaml-parser.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
 
-import type { ConvertedPrompt } from '../../../../../engine/execution/types.js';
+import { serializeYaml } from '#shared/utils/yaml/yaml-parser.js';
 
 /** Hunk type inferred from structuredPatch return */
 type Hunk = ReturnType<typeof structuredPatch>['hunks'][number];

--- a/server/src/mcp/tools/resource-manager/prompt/analysis/prompt-analyzer.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/analysis/prompt-analyzer.ts
@@ -3,11 +3,12 @@
  * Semantic analysis and classification engine
  */
 
-import { ContentAnalyzer } from '../../../../../modules/semantic/configurable-semantic-analyzer.js';
-import { type Logger } from '../../../../../shared/types/index.js';
 import { PromptClassification, AnalysisResult, PromptResourceDependencies } from '../core/types.js';
 
-import type { ConvertedPrompt } from '../../../../../engine/execution/types.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+
+import { ContentAnalyzer } from '#modules/semantic/configurable-semantic-analyzer.js';
+import { type Logger } from '#shared/types/index.js';
 
 /**
  * Prompt analysis engine for semantic classification and intelligence feedback

--- a/server/src/mcp/tools/resource-manager/prompt/core/context.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/core/context.ts
@@ -1,7 +1,5 @@
 // @lifecycle canonical - Shared context for prompt resource services.
 
-import { VersionHistoryService } from '../../../../../modules/versioning/index.js';
-
 import type { PromptResourceData, PromptResourceDependencies } from './types.js';
 import type { ComparisonEngine } from '../analysis/comparison-engine.js';
 import type { GateAnalyzer } from '../analysis/gate-analyzer.js';
@@ -10,6 +8,8 @@ import type { PromptAnalyzer } from '../analysis/prompt-analyzer.js';
 import type { FileOperations } from '../operations/file-operations.js';
 import type { FilterParser } from '../search/filter-parser.js';
 import type { PromptMatcher } from '../search/prompt-matcher.js';
+
+import { VersionHistoryService } from '#modules/versioning/index.js';
 
 export interface PromptResourceContext {
   dependencies: PromptResourceDependencies;

--- a/server/src/mcp/tools/resource-manager/prompt/core/types.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/core/types.ts
@@ -3,15 +3,15 @@
  * Shared types and interfaces for prompt resource services.
  */
 
-import { FrameworkManager } from '../../../../../engine/frameworks/framework-manager.js';
-import { FrameworkStateStore } from '../../../../../engine/frameworks/framework-state-store.js';
-import { ContentAnalyzer } from '../../../../../modules/semantic/configurable-semantic-analyzer.js';
-import { type Logger, ToolResponse, ConfigManager } from '../../../../../shared/types/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { PromptData, Category } from '#modules/prompts/types.js';
 
-import type { ConvertedPrompt } from '../../../../../engine/execution/types.js';
-import type { PromptData, Category } from '../../../../../modules/prompts/types.js';
+import { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import { ContentAnalyzer } from '#modules/semantic/configurable-semantic-analyzer.js';
+import { type Logger, ToolResponse, ConfigManager } from '#shared/types/index.js';
 
-export type { CategoryResult } from '../../../../../modules/prompts/category-maintenance.js';
+export type { CategoryResult } from '#modules/prompts/category-maintenance.js';
 
 export interface PromptClassification {
   executionType: 'single' | 'chain';

--- a/server/src/mcp/tools/resource-manager/prompt/operations/file-operations.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/operations/file-operations.ts
@@ -8,21 +8,22 @@ import { existsSync, readdirSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { OperationResult, PromptResourceDependencies } from '../core/types.js';
+
+import type { ConfigManager, Logger } from '#shared/types/index.js';
+import type { ToolDefinitionInput } from '../../core/types.js';
+
 import {
   findYamlPromptInCategory,
   hasYamlPromptsInCategory,
   deleteYamlPrompt,
-} from '../../../../../modules/prompts/category-maintenance.js';
+} from '#modules/prompts/category-maintenance.js';
 import {
   ResourceMutationTransaction,
   ResourceVerificationService,
-} from '../../../../../modules/resources/services/index.js';
-import { safeWriteFile } from '../../../../../shared/utils/file-transactions.js';
-import { serializeYaml } from '../../../../../shared/utils/yaml/yaml-parser.js';
-import { OperationResult, PromptResourceDependencies } from '../core/types.js';
-
-import type { ConfigManager, Logger } from '../../../../../shared/types/index.js';
-import type { ToolDefinitionInput } from '../../core/types.js';
+} from '#modules/resources/services/index.js';
+import { safeWriteFile } from '#shared/utils/file-transactions.js';
+import { serializeYaml } from '#shared/utils/yaml/yaml-parser.js';
 
 export interface FileOperationsDependencies extends Pick<
   PromptResourceDependencies,

--- a/server/src/mcp/tools/resource-manager/prompt/prompt-resource-handler.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/prompt-resource-handler.ts
@@ -12,24 +12,22 @@ import { PromptMatcher } from './search/prompt-matcher.js';
 import { PromptDiscoveryProcessor } from './services/prompt-discovery-processor.js';
 import { PromptLifecycleProcessor } from './services/prompt-lifecycle-processor.js';
 import { PromptVersioningProcessor } from './services/prompt-versioning-processor.js';
-import { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import { ContentAnalyzer } from '../../../../modules/semantic/configurable-semantic-analyzer.js';
-import { VersionHistoryService } from '../../../../modules/versioning/index.js';
-import { logMcpToolChange } from '../../../../runtime/resource-change-tracking.js';
-import { type Logger, ToolResponse, ConfigManager } from '../../../../shared/types/index.js';
-import {
-  ValidationError,
-  handleError as utilsHandleError,
-} from '../../../../shared/utils/index.js';
 import { promptResourceMetadata } from '../../../metadata/definitions/prompt-resource.js';
 import { recordActionInvocation } from '../../../metadata/usage-tracker.js';
 
-import type { ConvertedPrompt } from '../../../../engine/execution/types.js';
-import type { PromptData, Category } from '../../../../modules/prompts/types.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { PromptData, Category } from '#modules/prompts/types.js';
 import type { PromptResourceActionId } from '../../../metadata/definitions/prompt-resource.js';
 import type { ActionDescriptor } from '../../../metadata/definitions/types.js';
 import type { PromptResourceHandlerPort } from '../core/types.js';
+
+import { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import { ContentAnalyzer } from '#modules/semantic/configurable-semantic-analyzer.js';
+import { VersionHistoryService } from '#modules/versioning/index.js';
+import { logMcpToolChange } from '#runtime/resource-change-tracking.js';
+import { type Logger, ToolResponse, ConfigManager } from '#shared/types/index.js';
+import { ValidationError, handleError as utilsHandleError } from '#shared/utils/index.js';
 
 const PROMPT_RESOURCE_ACTIONS = promptResourceMetadata.data.actions;
 const PROMPT_RESOURCE_ACTION_MAP = new Map<PromptResourceActionId, ActionDescriptor>(
@@ -111,7 +109,7 @@ export class PromptResourceHandler implements PromptResourceHandlerPort {
     );
   }
 
-  setDatabasePort(db: import('../../../../shared/types/persistence.js').DatabasePort): void {
+  setDatabasePort(db: import('#shared/types/persistence.js').DatabasePort): void {
     this.versionHistoryService.setDatabasePort(db);
   }
 

--- a/server/src/mcp/tools/resource-manager/prompt/search/filter-parser.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/search/filter-parser.ts
@@ -6,7 +6,7 @@
 import { SmartFilters } from '../core/types.js';
 import { validateFilterSyntax } from '../utils/validation.js';
 
-import type { Logger } from '../../../../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 
 /**
  * Filter parsing engine for intelligent prompt discovery

--- a/server/src/mcp/tools/resource-manager/prompt/search/prompt-matcher.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/search/prompt-matcher.ts
@@ -3,10 +3,11 @@
  * Matching and fuzzy search logic for prompt discovery
  */
 
-import { type Logger } from '../../../../../shared/types/index.js';
 import { PromptClassification, SmartFilters } from '../core/types.js';
 
-import type { ConvertedPrompt } from '../../../../../engine/execution/types.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+
+import { type Logger } from '#shared/types/index.js';
 
 /**
  * Prompt matching engine with fuzzy search capabilities

--- a/server/src/mcp/tools/resource-manager/prompt/services/prompt-discovery-processor.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/services/prompt-discovery-processor.ts
@@ -1,6 +1,5 @@
 // @lifecycle canonical - Prompt discovery and analysis operations.
 
-import { ToolResponse } from '../../../../../shared/types/index.js';
 import { promptResourceMetadata } from '../../../../metadata/definitions/prompt-resource.js';
 import { GateAnalyzer } from '../analysis/gate-analyzer.js';
 import { PromptAnalyzer } from '../analysis/prompt-analyzer.js';
@@ -10,6 +9,8 @@ import { PromptMatcher } from '../search/prompt-matcher.js';
 import { validateChainStepReferences, validateRequiredFields } from '../utils/validation.js';
 
 import type { PromptResourceActionId } from '../../../../metadata/definitions/prompt-resource.js';
+
+import { ToolResponse } from '#shared/types/index.js';
 
 const PROMPT_RESOURCE_ACTIONS = promptResourceMetadata.data.actions;
 

--- a/server/src/mcp/tools/resource-manager/prompt/services/prompt-lifecycle-processor.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/services/prompt-lifecycle-processor.ts
@@ -1,8 +1,5 @@
 // @lifecycle canonical - Prompt create/update/delete operations.
 
-import { PromptReferenceValidator } from '../../../../../engine/execution/reference/index.js';
-import { ToolResponse } from '../../../../../shared/types/index.js';
-import { PromptError } from '../../../../../shared/utils/index.js';
 import { ComparisonEngine } from '../analysis/comparison-engine.js';
 import { ObjectDiffGenerator } from '../analysis/object-diff-generator.js';
 import { PromptAnalyzer } from '../analysis/prompt-analyzer.js';
@@ -18,8 +15,12 @@ import {
   validateToolDefinitions,
 } from '../utils/validation.js';
 
-import type { ConvertedPrompt } from '../../../../../engine/execution/types.js';
-import type { PromptData } from '../../../../../modules/prompts/types.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { PromptData } from '#modules/prompts/types.js';
+
+import { PromptReferenceValidator } from '#engine/execution/reference/index.js';
+import { ToolResponse } from '#shared/types/index.js';
+import { PromptError } from '#shared/utils/index.js';
 
 export class PromptLifecycleProcessor {
   private readonly context: PromptResourceContext;

--- a/server/src/mcp/tools/resource-manager/prompt/services/prompt-versioning-processor.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/services/prompt-versioning-processor.ts
@@ -1,10 +1,11 @@
 // @lifecycle canonical - Prompt version history operations.
 
-import { ToolResponse } from '../../../../../shared/types/index.js';
 import { ObjectDiffGenerator } from '../analysis/object-diff-generator.js';
 import { PromptResourceContext } from '../core/context.js';
 import { FileOperations } from '../operations/file-operations.js';
 import { validateRequiredFields } from '../utils/validation.js';
+
+import { ToolResponse } from '#shared/types/index.js';
 
 export class PromptVersioningProcessor {
   private readonly context: PromptResourceContext;

--- a/server/src/mcp/tools/resource-manager/prompt/utils/validation.ts
+++ b/server/src/mcp/tools/resource-manager/prompt/utils/validation.ts
@@ -3,12 +3,13 @@
  * Field validation and error handling utilities
  */
 
-import { ValidationError } from '../../../../../shared/utils/index.js';
 import { promptResourceMetadata } from '../../../../metadata/definitions/prompt-resource.js';
 import { ValidationContext } from '../core/types.js';
 
 import type { PromptResourceActionId } from '../../../../metadata/definitions/prompt-resource.js';
 import type { ToolDefinitionInput } from '../../core/types.js';
+
+import { ValidationError } from '#shared/utils/index.js';
 
 /**
  * Maps MCP parameter names (snake_case) to internal promptData field names (camelCase).

--- a/server/src/mcp/tools/schemas/resource-manager.schema.ts
+++ b/server/src/mcp/tools/schemas/resource-manager.schema.ts
@@ -8,7 +8,7 @@
 
 import { z } from 'zod';
 
-import { ChainStepSchema } from '../../../modules/prompts/prompt-schema.js';
+import { ChainStepSchema } from '#modules/prompts/prompt-schema.js';
 
 // ---------------------------------------------------------------------------
 // Schema

--- a/server/src/mcp/tools/shared/structured-response-builder.ts
+++ b/server/src/mcp/tools/shared/structured-response-builder.ts
@@ -9,11 +9,7 @@
  * when they declare an outputSchema, as required by MCP protocol.
  */
 
-import type {
-  GateValidationInfo,
-  McpErrorCode,
-  ToolResponse,
-} from '../../../shared/types/index.js';
+import type { GateValidationInfo, McpErrorCode, ToolResponse } from '#shared/types/index.js';
 import type { ErrorContext } from '../types/shared-types.js';
 
 /**

--- a/server/src/mcp/tools/skills-sync.ts
+++ b/server/src/mcp/tools/skills-sync.ts
@@ -4,15 +4,15 @@ import { format } from 'node:util';
 
 import yaml from 'js-yaml';
 
+import type { DatabasePort, Logger, ToolResponse } from '#shared/types/index.js';
+
 import {
   getSkillsSyncConfigPath,
   listSupportedSkillsSyncClients,
   runSkillsSyncCommand,
   type ResourceType,
   type SkillsSyncOutput,
-} from '../../modules/skills-sync/service.js';
-
-import type { DatabasePort, Logger, ToolResponse } from '../../shared/types/index.js';
+} from '#modules/skills-sync/service.js';
 
 const SKILLS_SYNC_ACTIONS = ['status', 'export', 'sync', 'diff', 'pull', 'clone'] as const;
 type SkillsSyncAction = (typeof SKILLS_SYNC_ACTIONS)[number];

--- a/server/src/mcp/tools/system-control/core/action-handler-base.ts
+++ b/server/src/mcp/tools/system-control/core/action-handler-base.ts
@@ -1,15 +1,15 @@
 // @lifecycle canonical - Abstract base class for system_control action handlers.
 
-import type { SystemControlContext } from './types.js';
-import type { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import type { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import type { GateStateStore } from '../../../../engine/gates/gate-state-store.js';
+import type { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import type { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import type { GateStateStore } from '#engine/gates/gate-state-store.js';
 import type {
   StateStoreOptions,
   ConfigManager,
   Logger,
   ToolResponse,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
+import type { SystemControlContext } from './types.js';
 import type { SafeConfigWriter } from '../../config-utils.js';
 
 /**

--- a/server/src/mcp/tools/system-control/core/response-utils.ts
+++ b/server/src/mcp/tools/system-control/core/response-utils.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Shared response utilities for system_control handlers.
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 
 export function createStructuredResponse(
   content: any,

--- a/server/src/mcp/tools/system-control/core/types.ts
+++ b/server/src/mcp/tools/system-control/core/types.ts
@@ -1,10 +1,10 @@
 // @lifecycle canonical - Core types for system_control action handlers.
 
-import type { FrameworkManager } from '../../../../engine/frameworks/framework-manager.js';
-import type { FrameworkStateStore } from '../../../../engine/frameworks/framework-state-store.js';
-import type { PromptGuidanceService } from '../../../../engine/frameworks/prompt-guidance/index.js';
-import type { GateStateStore } from '../../../../engine/gates/gate-state-store.js';
-import type { GateGuidanceRenderer } from '../../../../engine/gates/guidance/GateGuidanceRenderer.js';
+import type { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import type { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import type { PromptGuidanceService } from '#engine/frameworks/prompt-guidance/index.js';
+import type { GateStateStore } from '#engine/gates/gate-state-store.js';
+import type { GateGuidanceRenderer } from '#engine/gates/guidance/GateGuidanceRenderer.js';
 import type {
   StateStoreOptions,
   ConfigManager,
@@ -12,7 +12,7 @@ import type {
   Logger,
   ToolResponse,
   ChainSessionService,
-} from '../../../../shared/types/index.js';
+} from '#shared/types/index.js';
 import type { SafeConfigWriter } from '../../config-utils.js';
 import type { ResponseFormatter } from '../../prompt-engine/processors/response-formatter.js';
 

--- a/server/src/mcp/tools/system-control/handlers/analytics-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/analytics-action-handler.ts
@@ -2,7 +2,7 @@
 
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { SystemAnalytics } from '../core/types.js';
 
 export class AnalyticsActionHandler extends ActionHandler {

--- a/server/src/mcp/tools/system-control/handlers/changes-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/changes-action-handler.ts
@@ -1,13 +1,10 @@
 // @lifecycle canonical - Handler for resource change tracking operations.
 
-import { getResourceChangeTracker } from '../../../../runtime/resource-change-tracking.js';
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type {
-  ToolResponse,
-  ChangeSource,
-  TrackedResourceType,
-} from '../../../../shared/types/index.js';
+import type { ToolResponse, ChangeSource, TrackedResourceType } from '#shared/types/index.js';
+
+import { getResourceChangeTracker } from '#runtime/resource-change-tracking.js';
 
 export class ChangesActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/config-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/config-action-handler.ts
@@ -1,12 +1,13 @@
 // @lifecycle canonical - Handler for configuration management operations.
 
-import { handleError as utilsHandleError } from '../../../../shared/utils/index.js';
 import { validateConfigInput } from '../../config-utils.js';
 import { ActionHandler } from '../core/action-handler-base.js';
 import { createStructuredResponse } from '../core/response-utils.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 import type { ConfigKey } from '../../config-utils.js';
+
+import { handleError as utilsHandleError } from '#shared/utils/index.js';
 
 export class ConfigActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/framework-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/framework-action-handler.ts
@@ -1,9 +1,10 @@
 // @lifecycle canonical - Handler for framework management operations.
 
-import { getDefaultRuntimeLoader } from '../../../../engine/frameworks/definitions/index.js';
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
+
+import { getDefaultRuntimeLoader } from '#engine/frameworks/definitions/index.js';
 
 export class FrameworkActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/gate-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/gate-action-handler.ts
@@ -2,7 +2,7 @@
 
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 
 export class GateActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/guide-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/guide-action-handler.ts
@@ -3,7 +3,7 @@
 import { systemControlMetadata } from '../../../metadata/definitions/system-control.js';
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 
 export class GuideActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/injection-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/injection-action-handler.ts
@@ -1,5 +1,9 @@
 // @lifecycle canonical - Handler for injection control operations.
 
+import { ActionHandler } from '../core/action-handler-base.js';
+
+import type { ToolResponse } from '#shared/types/index.js';
+
 import {
   INJECTION_TYPES,
   INJECTION_TYPE_DESCRIPTIONS,
@@ -8,10 +12,7 @@ import {
   getSessionOverrideResolver,
   initSessionOverrideResolver,
   type InjectionType,
-} from '../../../../engine/execution/pipeline/decisions/injection/index.js';
-import { ActionHandler } from '../core/action-handler-base.js';
-
-import type { ToolResponse } from '../../../../shared/types/index.js';
+} from '#engine/execution/pipeline/decisions/injection/index.js';
 
 export class InjectionActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/maintenance-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/maintenance-action-handler.ts
@@ -2,7 +2,7 @@
 
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 
 export class MaintenanceActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/session-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/session-action-handler.ts
@@ -2,7 +2,7 @@
 
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 
 export class SessionActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/handlers/status-action-handler.ts
+++ b/server/src/mcp/tools/system-control/handlers/status-action-handler.ts
@@ -2,7 +2,7 @@
 
 import { ActionHandler } from '../core/action-handler-base.js';
 
-import type { ToolResponse } from '../../../../shared/types/index.js';
+import type { ToolResponse } from '#shared/types/index.js';
 
 export class StatusActionHandler extends ActionHandler {
   async execute(args: any): Promise<ToolResponse> {

--- a/server/src/mcp/tools/system-control/system-control-router.ts
+++ b/server/src/mcp/tools/system-control/system-control-router.ts
@@ -17,9 +17,16 @@ import { InjectionActionHandler } from './handlers/injection-action-handler.js';
 import { MaintenanceActionHandler } from './handlers/maintenance-action-handler.js';
 import { SessionActionHandler } from './handlers/session-action-handler.js';
 import { StatusActionHandler } from './handlers/status-action-handler.js';
-import { FrameworkManager } from '../../../engine/frameworks/framework-manager.js';
-import { FrameworkStateStore } from '../../../engine/frameworks/framework-state-store.js';
-import { GateStateStore } from '../../../engine/gates/gate-state-store.js';
+import { ResponseFormatter } from '../prompt-engine/processors/response-formatter.js';
+
+import type { PromptGuidanceService } from '#engine/frameworks/prompt-guidance/index.js';
+import type { GateGuidanceRenderer } from '#engine/gates/guidance/GateGuidanceRenderer.js';
+import type { ActionHandler } from './core/action-handler-base.js';
+import type { SystemAnalytics, SystemControlContext } from './core/types.js';
+
+import { FrameworkManager } from '#engine/frameworks/framework-manager.js';
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import { GateStateStore } from '#engine/gates/gate-state-store.js';
 import {
   type ConfigManager,
   type MetricsCollector,
@@ -27,15 +34,9 @@ import {
   type ToolResponse,
   type ChainSessionService,
   StateStoreOptions,
-} from '../../../shared/types/index.js';
-import { resolveRequestIdentity } from '../../../shared/utils/request-identity-resolver.js';
-import { resolveContinuityScopeId } from '../../../shared/utils/request-identity-scope.js';
-import { ResponseFormatter } from '../prompt-engine/processors/response-formatter.js';
-
-import type { ActionHandler } from './core/action-handler-base.js';
-import type { SystemAnalytics, SystemControlContext } from './core/types.js';
-import type { PromptGuidanceService } from '../../../engine/frameworks/prompt-guidance/index.js';
-import type { GateGuidanceRenderer } from '../../../engine/gates/guidance/GateGuidanceRenderer.js';
+} from '#shared/types/index.js';
+import { resolveRequestIdentity } from '#shared/utils/request-identity-resolver.js';
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 function isSystemControlActionId(value: string): value is SystemControlActionId {
   return (SYSTEM_CONTROL_ACTION_IDS as readonly string[]).includes(value);

--- a/server/src/mcp/tools/tool-description-loader.ts
+++ b/server/src/mcp/tools/tool-description-loader.ts
@@ -20,17 +20,18 @@ import {
   preloadStyleDescriptions,
   buildActiveConfig,
 } from './tool-description-overlays.js';
-import { FrameworkStateStore } from '../../engine/frameworks/framework-state-store.js';
 
-import type { FrameworkToolDescriptions } from '../../engine/frameworks/types/index.js';
-import type { StyleToolDescriptionYaml } from '../../modules/formatting/core/style-schema.js';
+import type { FrameworkToolDescriptions } from '#engine/frameworks/types/index.js';
+import type { StyleToolDescriptionYaml } from '#modules/formatting/core/style-schema.js';
 import type {
   ConfigManager,
   Logger,
   ToolDescription,
   ToolDescriptionsConfig,
   ResolvedFrameworkConfig,
-} from '../../shared/types/index.js';
+} from '#shared/types/index.js';
+
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
 
 /**
  * @deprecated Emergency fallback only - do not edit.

--- a/server/src/mcp/tools/tool-description-overlays.ts
+++ b/server/src/mcp/tools/tool-description-overlays.ts
@@ -10,15 +10,15 @@
  * base description loading and event management.
  */
 
+import type { FrameworkToolDescriptions } from '#engine/frameworks/types/index.js';
+import type { StyleToolDescriptionYaml } from '#modules/formatting/core/style-schema.js';
+import type { Logger, ToolDescription, ToolDescriptionsConfig } from '#shared/types/index.js';
+
 import {
   getDefaultRuntimeLoader,
   createGenericGuide,
-} from '../../engine/frameworks/definitions/index.js';
-import { getDefaultStyleDefinitionLoader } from '../../modules/formatting/core/style-definition-loader.js';
-
-import type { FrameworkToolDescriptions } from '../../engine/frameworks/types/index.js';
-import type { StyleToolDescriptionYaml } from '../../modules/formatting/core/style-schema.js';
-import type { Logger, ToolDescription, ToolDescriptionsConfig } from '../../shared/types/index.js';
+} from '#engine/frameworks/definitions/index.js';
+import { getDefaultStyleDefinitionLoader } from '#modules/formatting/core/style-definition-loader.js';
 
 /**
  * Normalize framework keys for consistent lookup (case-insensitive)

--- a/server/src/mcp/tools/types/shared-types.ts
+++ b/server/src/mcp/tools/types/shared-types.ts
@@ -9,7 +9,7 @@
  */
 
 // Import consolidated error handling types
-import { ErrorContext, ValidationResult } from '../../../shared/utils/errorHandling.js';
+import { ErrorContext, ValidationResult } from '#shared/utils/errorHandling.js';
 
 /**
  * MCP Tool callback extra parameter

--- a/server/src/modules/automation/core/script-definition-loader.ts
+++ b/server/src/modules/automation/core/script-definition-loader.ts
@@ -34,7 +34,6 @@ import {
   type ScriptToolSchemaValidationResult,
   type ScriptToolYaml,
 } from './script-schema.js';
-import { loadYamlFileSync } from '../../../shared/utils/yaml/index.js';
 import { DEFAULT_EXECUTION_CONFIG } from '../types.js';
 
 import type {
@@ -44,6 +43,8 @@ import type {
   JSONSchemaDefinition,
   ExecutionConfig,
 } from '../types.js';
+
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 // Re-export validation types
 export type { ScriptToolSchemaValidationResult } from './script-schema.js';

--- a/server/src/modules/automation/core/workspace-script-loader.ts
+++ b/server/src/modules/automation/core/workspace-script-loader.ts
@@ -16,11 +16,12 @@ import { join } from 'path';
 
 import { ScriptToolDefinitionLoader } from './script-definition-loader.js';
 import { validateScriptToolSchema, type ScriptToolYaml } from './script-schema.js';
-import { loadYamlFileSync } from '../../../shared/utils/yaml/index.js';
 import { DEFAULT_EXECUTION_CONFIG } from '../types.js';
 
-import type { ScriptLoader } from '../../../engine/execution/reference/script-reference-resolver.js';
+import type { ScriptLoader } from '#engine/execution/reference/script-reference-resolver.js';
 import type { LoadedScriptTool, ScriptToolLoaderConfig, JSONSchemaDefinition } from '../types.js';
+
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 /**
  * Configuration for WorkspaceScriptLoader

--- a/server/src/modules/automation/detection/tool-detection-service.ts
+++ b/server/src/modules/automation/detection/tool-detection-service.ts
@@ -21,7 +21,7 @@
 
 import { DEFAULT_EXECUTION_CONFIG } from '../types.js';
 
-import type { ToolDetectionServicePort } from '../../../shared/types/index.js';
+import type { ToolDetectionServicePort } from '#shared/types/index.js';
 import type {
   LoadedScriptTool,
   ToolDetectionMatch,

--- a/server/src/modules/automation/execution/script-executor.ts
+++ b/server/src/modules/automation/execution/script-executor.ts
@@ -17,9 +17,7 @@
 import { existsSync } from 'node:fs';
 import { extname, join } from 'node:path';
 
-import { executeProcess } from '../../../shared/utils/process.js';
-
-import type { ScriptExecutorPort } from '../../../shared/types/index.js';
+import type { ScriptExecutorPort } from '#shared/types/index.js';
 import type {
   LoadedScriptTool,
   ScriptExecutionRequest,
@@ -28,6 +26,8 @@ import type {
   ScriptInputValidationResult,
   JSONSchemaDefinition,
 } from '../types.js';
+
+import { executeProcess } from '#shared/utils/process.js';
 
 /**
  * Runtime command mappings for script execution.

--- a/server/src/modules/automation/execution/tool-trigger-filter.ts
+++ b/server/src/modules/automation/execution/tool-trigger-filter.ts
@@ -23,7 +23,7 @@ import {
   type PendingConfirmationTracker,
 } from './pending-confirmation-tracker.js';
 
-import type { ToolTriggerFilterPort } from '../../../shared/types/index.js';
+import type { ToolTriggerFilterPort } from '#shared/types/index.js';
 import type {
   LoadedScriptTool,
   ToolDetectionMatch,

--- a/server/src/modules/automation/hot-reload/script-hot-reload.ts
+++ b/server/src/modules/automation/hot-reload/script-hot-reload.ts
@@ -17,7 +17,7 @@
  * @see plans/script-tools-implementation.md for the full implementation plan
  */
 
-import type { Logger } from '../../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 import type { HotReloadEvent } from '../../hot-reload/hot-reload-observer.js';
 import type { ScriptToolDefinitionLoader } from '../core/script-definition-loader.js';
 

--- a/server/src/modules/automation/types.ts
+++ b/server/src/modules/automation/types.ts
@@ -25,4 +25,4 @@ export {
   type ToolMatchReason,
   type ToolPendingConfirmation,
   type TriggerType,
-} from '../../shared/types/automation.js';
+} from '#shared/types/automation.js';

--- a/server/src/modules/chains/execution-record-store.ts
+++ b/server/src/modules/chains/execution-record-store.ts
@@ -22,8 +22,6 @@ import { monotonicFactory } from 'ulid';
  */
 const ulid = monotonicFactory();
 
-import { resolveContinuityScopeId } from '../../shared/utils/request-identity-scope.js';
-
 import type {
   ExecutionRecord,
   StepLifecycle,
@@ -31,9 +29,11 @@ import type {
   InputRequiredReason,
   EvidencePayload,
   GateVerdictSummary,
-} from '../../shared/types/chain-execution.js';
-import type { Logger } from '../../shared/types/index.js';
-import type { DatabasePort, StateStoreOptions } from '../../shared/types/persistence.js';
+} from '#shared/types/chain-execution.js';
+import type { Logger } from '#shared/types/index.js';
+import type { DatabasePort, StateStoreOptions } from '#shared/types/persistence.js';
+
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 interface ExecutionRecordRow {
   execution_id: string;

--- a/server/src/modules/chains/manager.ts
+++ b/server/src/modules/chains/manager.ts
@@ -11,8 +11,6 @@
  */
 
 import { DirectChainRunRegistry, type ChainRunRegistry } from './run-registry.js';
-import { isTerminalRunStatus } from '../../shared/types/chain-session.js';
-import { resolveContinuityScopeId } from '../../shared/utils/request-identity-scope.js';
 import { ArgumentHistoryTracker, TextReferenceStore } from '../text-refs/index.js';
 
 import type {
@@ -24,7 +22,7 @@ import type {
   PendingShellVerificationSnapshot,
   StepMetadata,
   GateReviewPrompt,
-} from '../../shared/types/chain-execution.js';
+} from '#shared/types/chain-execution.js';
 import type {
   ChainSession,
   ChainSessionLookupOptions,
@@ -34,9 +32,12 @@ import type {
   ParsedCommandSnapshot,
   PersistedChainRunRegistry,
   SessionBlueprint,
-} from '../../shared/types/chain-session.js';
-import type { Logger } from '../../shared/types/index.js';
-import type { DatabasePort, StateStoreOptions } from '../../shared/types/persistence.js';
+} from '#shared/types/chain-session.js';
+import type { Logger } from '#shared/types/index.js';
+import type { DatabasePort, StateStoreOptions } from '#shared/types/persistence.js';
+
+import { isTerminalRunStatus } from '#shared/types/chain-session.js';
+import { resolveContinuityScopeId } from '#shared/utils/request-identity-scope.js';
 
 /**
  * Derive the sticky lifecycle value a milestone implies. `rendered` and `responded` are both
@@ -2076,7 +2077,7 @@ export type {
   ChainSessionService,
   ChainSessionSummary,
   SessionBlueprint,
-} from '../../shared/types/chain-session.js';
+} from '#shared/types/chain-session.js';
 
 /**
  * Create and configure a chain session store

--- a/server/src/modules/chains/run-registry.ts
+++ b/server/src/modules/chains/run-registry.ts
@@ -1,6 +1,6 @@
 // @lifecycle canonical - Persists chain run registry data via SQLite.
-import type { PersistedChainRunRegistry } from '../../shared/types/chain-session.js';
-import type { DatabasePort, StateStoreOptions } from '../../shared/types/persistence.js';
+import type { PersistedChainRunRegistry } from '#shared/types/chain-session.js';
+import type { DatabasePort, StateStoreOptions } from '#shared/types/persistence.js';
 
 export interface ChainRunRegistry {
   ensureInitialized(): Promise<void>;

--- a/server/src/modules/formatting/core/style-definition-loader.ts
+++ b/server/src/modules/formatting/core/style-definition-loader.ts
@@ -24,11 +24,12 @@ import {
   type StyleSchemaValidationResult,
   type StyleDefinitionYaml,
 } from './style-schema.js';
+
 import {
   loadYamlFileSync,
   discoverYamlDirectories,
   discoverNestedYamlDirectories,
-} from '../../../shared/utils/yaml/index.js';
+} from '#shared/utils/yaml/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/src/modules/formatting/hot-reload/style-hot-reload.ts
+++ b/server/src/modules/formatting/hot-reload/style-hot-reload.ts
@@ -8,7 +8,7 @@
  * @see GateHotReloadCoordinator for the pattern this follows
  */
 
-import type { Logger } from '../../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 import type { StyleDefinitionLoader, StyleDefinitionYaml } from '../core/index.js';
 
 /**

--- a/server/src/modules/formatting/style-manager.ts
+++ b/server/src/modules/formatting/style-manager.ts
@@ -18,9 +18,10 @@ import {
   type StyleLoaderStats,
   type StyleDefinitionYaml,
 } from './core/index.js';
-import { isGateActiveForContext } from '../../engine/gates/utils/gate-activation.js';
 
-import type { StyleManagerPort, Logger } from '../../shared/types/index.js';
+import type { StyleManagerPort, Logger } from '#shared/types/index.js';
+
+import { isGateActiveForContext } from '#engine/gates/utils/gate-activation.js';
 
 /**
  * Configuration for StyleManager

--- a/server/src/modules/hot-reload/file-observer.ts
+++ b/server/src/modules/hot-reload/file-observer.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 
 import chokidar, { type ChokidarOptions, type FSWatcher } from 'chokidar';
 
-import type { ConfigManager, Logger } from '../../shared/types/index.js';
+import type { ConfigManager, Logger } from '#shared/types/index.js';
 
 /**
  * File change event types

--- a/server/src/modules/hot-reload/hot-reload-observer.ts
+++ b/server/src/modules/hot-reload/hot-reload-observer.ts
@@ -19,7 +19,7 @@ import type {
   HotReloadEventType,
   FileChangeOperation,
   HotReloadEvent,
-} from '../../shared/types/index.js';
+} from '#shared/types/index.js';
 
 export type { HotReloadEventType, FileChangeOperation, HotReloadEvent };
 

--- a/server/src/modules/prompts/category-manager.ts
+++ b/server/src/modules/prompts/category-manager.ts
@@ -4,8 +4,6 @@
  * Handles category management logic with validation, organization, and relationship tracking
  */
 
-import { type Logger } from '../../shared/types/index.js';
-
 import type { Category, PromptData } from './types.js';
 
 // Import category interfaces from prompts/types.ts instead of redefining
@@ -14,6 +12,8 @@ import type {
   CategoryStatistics,
   CategoryPromptRelationship,
 } from './types.js';
+
+import { type Logger } from '#shared/types/index.js';
 
 /**
  * CategoryManager class

--- a/server/src/modules/prompts/converter.ts
+++ b/server/src/modules/prompts/converter.ts
@@ -7,15 +7,16 @@
 import * as path from 'node:path';
 
 import { PromptLoader } from './loader.js';
-import { isChainPrompt } from '../../shared/utils/chainUtils.js';
 import {
   ScriptToolDefinitionLoader,
   createScriptToolDefinitionLoader,
 } from '../automation/core/script-definition-loader.js';
 
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { PromptArgument, Logger } from '#shared/types/index.js';
 import type { PromptData } from './types.js';
-import type { ConvertedPrompt } from '../../engine/execution/types.js';
-import type { PromptArgument, Logger } from '../../shared/types/index.js';
+
+import { isChainPrompt } from '#shared/utils/chainUtils.js';
 
 /**
  * Resolve the registerWithMcp value using the priority chain:

--- a/server/src/modules/prompts/index.ts
+++ b/server/src/modules/prompts/index.ts
@@ -16,7 +16,6 @@ import { PromptConverter } from './converter.js';
 import { PromptLoader } from './loader.js';
 import { discoverPromptDirectories, buildWatchTargets } from './prompt-watch-setup.js';
 import { PromptRegistry } from './registry.js';
-import { type ConfigManager, type Logger } from '../../shared/types/index.js';
 import {
   HotReloadObserver,
   createHotReloadObserver,
@@ -26,9 +25,11 @@ import {
 import { ConversationStore } from '../text-refs/conversation.js';
 import { TextReferenceStore } from '../text-refs/index.js';
 
+import type { ConvertedPrompt } from '#engine/execution/types.js';
 import type { Category, CategoryPromptsResult, PromptData } from './types.js';
-import type { ConvertedPrompt } from '../../engine/execution/types.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { type ConfigManager, type Logger } from '#shared/types/index.js';
 
 /**
  * Main Prompt Asset Manager class that coordinates all prompt operations

--- a/server/src/modules/prompts/launcher-envelope.ts
+++ b/server/src/modules/prompts/launcher-envelope.ts
@@ -14,8 +14,8 @@
  * and requires no knowledge of the client's slash-command prefix.
  */
 
-import type { ConvertedPrompt } from '../../engine/execution/types.js';
-import type { PromptArgument } from '../../shared/types/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { PromptArgument } from '#shared/types/index.js';
 
 /** A single MCP prompt message (the shape returned by `prompts/get`). */
 export interface LauncherMessage {

--- a/server/src/modules/prompts/loader.ts
+++ b/server/src/modules/prompts/loader.ts
@@ -25,10 +25,11 @@ import {
   loadYamlPrompt as loadYamlPromptFn,
   loadAllYamlPrompts as loadAllYamlPromptsFn,
 } from './yaml-prompt-loader.js';
-import { type Logger } from '../../shared/types/index.js';
-import { loadYamlFileSync } from '../../shared/utils/yaml/index.js';
 
 import type { Category, CategoryPromptsResult, PromptData } from './types.js';
+
+import { type Logger } from '#shared/types/index.js';
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 // Re-export types from yaml-prompt-loader for backward compatibility
 export type { LoadedPromptFile } from './yaml-prompt-loader.js';

--- a/server/src/modules/prompts/prompt-refresh-service.ts
+++ b/server/src/modules/prompts/prompt-refresh-service.ts
@@ -1,8 +1,8 @@
 // @lifecycle canonical - Service that reloads prompts/categories on demand for MCP tools.
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { ConfigManager } from '#shared/types/index.js';
 import type { PromptAssetManager } from './index.js';
 import type { Category, PromptData } from './types.js';
-import type { ConvertedPrompt } from '../../engine/execution/types.js';
-import type { ConfigManager } from '../../shared/types/index.js';
 
 /**
  * Minimal interface for consumers that receive prompt data updates.

--- a/server/src/modules/prompts/prompt-watch-setup.ts
+++ b/server/src/modules/prompts/prompt-watch-setup.ts
@@ -1,7 +1,7 @@
 // @lifecycle canonical - Directory discovery and watch-target building for hot-reload setup.
 import * as path from 'node:path';
 
-import type { Logger } from '../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 
 /** Minimal interface for checking YAML prompt presence in a directory. */
 export interface YamlPromptChecker {

--- a/server/src/modules/prompts/registry.ts
+++ b/server/src/modules/prompts/registry.ts
@@ -7,12 +7,13 @@
 import { z } from 'zod';
 
 import { buildLauncherMessages } from './launcher-envelope.js';
-import { type ConfigManager, type Logger } from '../../shared/types/index.js';
-import { isChainPrompt } from '../../shared/utils/chainUtils.js';
 import { ConversationStore } from '../text-refs/conversation.js';
 
-import type { ConvertedPrompt } from '../../engine/execution/types.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { type ConfigManager, type Logger } from '#shared/types/index.js';
+import { isChainPrompt } from '#shared/utils/chainUtils.js';
 // TemplateProcessor functionality consolidated into UnifiedPromptProcessor
 
 /**
@@ -40,7 +41,7 @@ export class PromptRegistry {
     args: Record<string, string>,
     specialContext: Record<string, string> = {}
   ): Promise<string> {
-    const { processTemplate } = await import('../../shared/utils/jsonUtils.js');
+    const { processTemplate } = await import('#shared/utils/jsonUtils.js');
     return processTemplate(template, args, specialContext);
   }
 

--- a/server/src/modules/prompts/types.ts
+++ b/server/src/modules/prompts/types.ts
@@ -8,7 +8,7 @@
 
 // Cross-layer types canonical definitions live in shared/types/index.ts.
 // Import only what's used locally by remaining interfaces.
-import type { ChainStep, PromptData } from '../../shared/types/index.js';
+import type { ChainStep, PromptData } from '#shared/types/index.js';
 
 /**
  * A category for organizing prompts
@@ -32,7 +32,7 @@ export type {
   GateDefinition,
   PromptData,
   PromptGateConfiguration,
-} from '../../shared/types/index.js';
+} from '#shared/types/index.js';
 
 // PromptData definition moved to shared/types/index.ts (re-exported above).
 

--- a/server/src/modules/prompts/yaml-prompt-loader.ts
+++ b/server/src/modules/prompts/yaml-prompt-loader.ts
@@ -14,12 +14,13 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import * as path from 'node:path';
 
 import { validatePromptYaml, type PromptYaml } from './prompt-schema.js';
-import { type Logger, PromptArgument } from '../../shared/types/index.js';
-import { INJECTION_TYPES } from '../../shared/types/injection.js';
-import { loadYamlFileSync } from '../../shared/utils/yaml/index.js';
 
+import type { PromptInjectionConfig, PromptInjectionRule } from '#shared/types/injection.js';
 import type { PromptData } from './types.js';
-import type { PromptInjectionConfig, PromptInjectionRule } from '../../shared/types/injection.js';
+
+import { type Logger, PromptArgument } from '#shared/types/index.js';
+import { INJECTION_TYPES } from '#shared/types/injection.js';
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 // ============================================
 // Shared Types (used by both YAML and Markdown loading)

--- a/server/src/modules/resources/index.ts
+++ b/server/src/modules/resources/index.ts
@@ -28,8 +28,8 @@ import { registerGateResources } from './handlers/gate-resources.js';
 import { registerObservabilityResources } from './handlers/observability-resources.js';
 import { registerPromptResources } from './handlers/prompt-resources.js';
 
+import type { Logger } from '#shared/types/index.js';
 import type { ResourceDependencies } from './types.js';
-import type { Logger } from '../../shared/types/index.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 export { RESOURCE_URI_PATTERNS, ResourceNotFoundError } from './types.js';

--- a/server/src/modules/resources/services/resource-verification-service.ts
+++ b/server/src/modules/resources/services/resource-verification-service.ts
@@ -1,10 +1,11 @@
 // @lifecycle canonical - Canonical resource schema verification service for CLI and MCP write paths.
-import { validateFrameworkSchema } from '../../../engine/frameworks/definitions/framework-schema.js';
-import { validateGateSchema } from '../../../engine/gates/core/gate-schema.js';
 import { validateScriptToolSchema } from '../../../modules/automation/core/script-schema.js';
 import { validateStyleSchema } from '../../../modules/formatting/core/style-schema.js';
 import { validatePromptYaml } from '../../../modules/prompts/prompt-schema.js';
-import { loadYamlFileSync } from '../../../shared/utils/yaml/index.js';
+
+import { validateFrameworkSchema } from '#engine/frameworks/definitions/framework-schema.js';
+import { validateGateSchema } from '#engine/gates/core/gate-schema.js';
+import { loadYamlFileSync } from '#shared/utils/yaml/index.js';
 
 export type ResourceVerificationType = 'prompts' | 'gates' | 'frameworks' | 'styles' | 'tools';
 

--- a/server/src/modules/resources/types.ts
+++ b/server/src/modules/resources/types.ts
@@ -6,7 +6,7 @@
  * Resources provide token-efficient read-only access to prompts, gates, and observability data.
  */
 
-import type { Logger } from '../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 /**

--- a/server/src/modules/semantic/configurable-semantic-analyzer.ts
+++ b/server/src/modules/semantic/configurable-semantic-analyzer.ts
@@ -13,16 +13,13 @@
  * - LLM infrastructure is preserved for future intelligent analysis
  */
 
-import { ConvertedPrompt } from '../../engine/execution/types.js';
-import { BUILTIN_FRAMEWORK_TYPES } from '../../engine/frameworks/types/framework-types.js';
 import { SemanticAnalysisConfig } from '../../types.js';
 
+import type { ContentAnalysisResult, ContentAnalyzerPort, Logger } from '#shared/types/index.js';
 import type { LLMClient } from './types.js';
-import type {
-  ContentAnalysisResult,
-  ContentAnalyzerPort,
-  Logger,
-} from '../../shared/types/index.js';
+
+import { ConvertedPrompt } from '#engine/execution/types.js';
+import { BUILTIN_FRAMEWORK_TYPES } from '#engine/frameworks/types/framework-types.js';
 
 // Configuration constants
 const CACHE_ANALYSIS = true;
@@ -371,7 +368,7 @@ export class ContentAnalyzer implements ContentAnalyzerPort {
   }
 }
 
-export type { ContentAnalysisResult } from '../../shared/types/index.js';
+export type { ContentAnalysisResult } from '#shared/types/index.js';
 export type { LLMClient } from './types.js';
 
 /**

--- a/server/src/modules/semantic/integrations/index.ts
+++ b/server/src/modules/semantic/integrations/index.ts
@@ -6,9 +6,10 @@
  * Handles LLM clients for content analysis
  */
 
-import { type Logger, SemanticAnalysisConfig } from '../../../shared/types/index.js';
 import { ContentAnalyzer, createContentAnalyzer } from '../configurable-semantic-analyzer.js';
 import { LLMClientFactory, loadLLMConfigFromEnv } from './llm-clients.js';
+
+import { type Logger, SemanticAnalysisConfig } from '#shared/types/index.js';
 
 /**
  * Integration factory for content analyzer

--- a/server/src/modules/semantic/integrations/llm-clients.ts
+++ b/server/src/modules/semantic/integrations/llm-clients.ts
@@ -6,9 +6,9 @@
  * to enable intelligent semantic analysis when configured.
  */
 
-import { type Logger, LLMIntegrationConfig, LLMProvider } from '../../../shared/types/index.js';
-
 import type { LLMClient } from '../types.js';
+
+import { type Logger, LLMIntegrationConfig, LLMProvider } from '#shared/types/index.js';
 
 /**
  * Base LLM client with common functionality

--- a/server/src/modules/skills-sync/service.ts
+++ b/server/src/modules/skills-sync/service.ts
@@ -16,9 +16,9 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 import { createTwoFilesPatch } from 'diff';
 
-import { computeContentHash } from '../../shared/utils/hash.js';
-import { loadHistory } from '../../cli-shared/version-history.js';
-import type { DatabasePort } from '../../shared/types/persistence.js';
+import { computeContentHash } from '#shared/utils/hash.js';
+import { loadHistory } from '#cli-shared/version-history.js';
+import type { DatabasePort } from '#shared/types/persistence.js';
 import {
   ResourceMutationTransaction,
   ResourceVerificationError,
@@ -382,7 +382,7 @@ interface SyncManifestEntry {
   sourceSnapshot?: Record<string, string>; // Raw source files at export time, for drift diffing
 }
 
-import type { ToolIndexEntry } from '../../shared/types/persistence.js';
+import type { ToolIndexEntry } from '#shared/types/persistence.js';
 
 export interface SkillsSyncOptions {
   command: string;

--- a/server/src/modules/text-refs/argument-history-tracker.ts
+++ b/server/src/modules/text-refs/argument-history-tracker.ts
@@ -14,8 +14,8 @@
  */
 import { ArgumentHistoryEntry, ReviewContext, PersistedArgumentHistory } from './types.js';
 
-import type { Logger } from '../../shared/types/index.js';
-import type { DatabasePort } from '../../shared/types/persistence.js';
+import type { Logger } from '#shared/types/index.js';
+import type { DatabasePort } from '#shared/types/persistence.js';
 
 const DEFAULT_STATE: PersistedArgumentHistory = {
   version: '1.0.0',

--- a/server/src/modules/text-refs/conversation.ts
+++ b/server/src/modules/text-refs/conversation.ts
@@ -4,7 +4,7 @@
  * Maintains lightweight conversation history for tooling and diagnostics.
  */
 
-import type { Logger, ConversationHistoryItem } from '../../shared/types/index.js';
+import type { Logger, ConversationHistoryItem } from '#shared/types/index.js';
 
 export class ConversationStore {
   private readonly logger: Logger;

--- a/server/src/modules/text-refs/index.ts
+++ b/server/src/modules/text-refs/index.ts
@@ -6,7 +6,7 @@
  * stage, session manager, and template renderer reads from the same snapshot.
  */
 
-import type { Logger } from '../../shared/types/index.js';
+import type { Logger } from '#shared/types/index.js';
 
 type StoredStepResult = {
   content: string;

--- a/server/src/modules/versioning/index.ts
+++ b/server/src/modules/versioning/index.ts
@@ -2,8 +2,8 @@
 
 export { VersionHistoryService } from './version-history-service.js';
 export type { VersioningConfigProvider } from './version-history-service.js';
-export type { VersioningConfig } from '../../shared/types/index.js';
-export { DEFAULT_VERSIONING_CONFIG } from '../../shared/types/index.js';
+export type { VersioningConfig } from '#shared/types/index.js';
+export { DEFAULT_VERSIONING_CONFIG } from '#shared/types/index.js';
 export type {
   VersionEntry,
   HistoryFile,

--- a/server/src/modules/versioning/version-history-service.ts
+++ b/server/src/modules/versioning/version-history-service.ts
@@ -1,5 +1,7 @@
 // @lifecycle canonical - Core service for managing resource version history
 
+import type { VersioningConfig, Logger } from '#shared/types/index.js';
+import type { DatabasePort } from '#shared/types/persistence.js';
 import type {
   VersionEntry,
   HistoryFile,
@@ -7,8 +9,6 @@ import type {
   RollbackResult,
   SaveVersionOptions,
 } from './types.js';
-import type { VersioningConfig, Logger } from '../../shared/types/index.js';
-import type { DatabasePort } from '../../shared/types/persistence.js';
 
 type ResourceType = 'prompt' | 'gate' | 'framework';
 

--- a/server/src/runtime/application.ts
+++ b/server/src/runtime/application.ts
@@ -23,28 +23,29 @@ import { buildResourceChangeTrackerAuxiliaryReloadConfig } from './resource-chan
 import { buildScriptAuxiliaryReloadConfig } from './script-hot-reload.js';
 import { startServerWithManagers } from './startup-server.js';
 import { TelemetryLifecycle } from './telemetry-lifecycle.js';
-import { FrameworkStateStore } from '../engine/frameworks/framework-state-store.js';
-import { GateManager } from '../engine/gates/gate-manager.js';
-import { ConfigLoader } from '../infra/config/index.js';
-import { HookRegistry } from '../infra/hooks/index.js';
-import { EnhancedLogger, Logger } from '../infra/logging/index.js';
-import { McpNotificationEmitter } from '../infra/observability/notifications/index.js';
-import { PromptAssetManager } from '../modules/prompts/index.js';
-import { reloadPromptData } from '../modules/prompts/prompt-refresh-service.js';
-import { registerResources, notifyResourcesChanged } from '../modules/resources/index.js';
-import { ConversationStore, createConversationStore } from '../modules/text-refs/conversation.js';
-import { TextReferenceStore } from '../modules/text-refs/index.js';
-import { ResolvedFrameworkConfig, TransportMode } from '../shared/types/index.js';
-import { ServiceOrchestrator } from '../shared/utils/service-orchestrator.js';
 
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { ServerLifecycle, TransportRouter } from '#infra/http/index.js';
+import type { ApiRouter } from '#mcp/http/api.js';
+import type { McpToolRouter } from '#mcp/tools/index.js';
+import type { ToolDescriptionLoader } from '#mcp/tools/tool-description-loader.js';
+import type { HotReloadEvent } from '#modules/hot-reload/hot-reload-observer.js';
+import type { Category, PromptData } from '#modules/prompts/types.js';
 import type { PathResolver } from './paths.js';
-import type { ConvertedPrompt } from '../engine/execution/types.js';
-import type { ServerLifecycle, TransportRouter } from '../infra/http/index.js';
-import type { ApiRouter } from '../mcp/http/api.js';
-import type { McpToolRouter } from '../mcp/tools/index.js';
-import type { ToolDescriptionLoader } from '../mcp/tools/tool-description-loader.js';
-import type { HotReloadEvent } from '../modules/hot-reload/hot-reload-observer.js';
-import type { Category, PromptData } from '../modules/prompts/types.js';
+
+import { FrameworkStateStore } from '#engine/frameworks/framework-state-store.js';
+import { GateManager } from '#engine/gates/gate-manager.js';
+import { ConfigLoader } from '#infra/config/index.js';
+import { HookRegistry } from '#infra/hooks/index.js';
+import { EnhancedLogger, Logger } from '#infra/logging/index.js';
+import { McpNotificationEmitter } from '#infra/observability/notifications/index.js';
+import { PromptAssetManager } from '#modules/prompts/index.js';
+import { reloadPromptData } from '#modules/prompts/prompt-refresh-service.js';
+import { registerResources, notifyResourcesChanged } from '#modules/resources/index.js';
+import { ConversationStore, createConversationStore } from '#modules/text-refs/conversation.js';
+import { TextReferenceStore } from '#modules/text-refs/index.js';
+import { ResolvedFrameworkConfig, TransportMode } from '#shared/types/index.js';
+import { ServiceOrchestrator } from '#shared/utils/service-orchestrator.js';
 
 /**
  * Application Runtime class
@@ -253,7 +254,7 @@ export class Application {
     // The emitter has canSend() guard that checks typeof notification === 'function'
     this.notificationEmitter.setServer(
       this
-        .mcpServer as unknown as import('../infra/observability/notifications/index.js').McpNotificationServer
+        .mcpServer as unknown as import('#infra/observability/notifications/index.js').McpNotificationServer
     );
     this.debugLog('HookRegistry and McpNotificationEmitter initialized');
 
@@ -744,10 +745,10 @@ export class Application {
       // Step 3.5: Re-sync resource index for hook consumption
       if (this.serverRoot) {
         try {
-          const { SqliteEngine } = await import('../infra/database/sqlite-engine.js');
-          const { createResourceIndexer } = await import('../infra/database/resource-indexer.js');
+          const { SqliteEngine } = await import('#infra/database/sqlite-engine.js');
+          const { createResourceIndexer } = await import('#infra/database/resource-indexer.js');
           const { ScriptToolDefinitionLoader } =
-            await import('../modules/automation/core/script-definition-loader.js');
+            await import('#modules/automation/core/script-definition-loader.js');
           const dbManager = await SqliteEngine.getInstance(this.serverRoot, this.logger);
           await dbManager.initialize();
           const resourcesDir =

--- a/server/src/runtime/context.ts
+++ b/server/src/runtime/context.ts
@@ -12,12 +12,13 @@ import * as path from 'node:path';
 import { resolveRuntimeLaunchOptions, RuntimeLaunchOptions } from './options.js';
 import { PathResolver } from './paths.js';
 import { resolvePackageRoot } from './startup.js';
-import { ConfigLoader } from '../infra/config/index.js';
-import { TransportRouter } from '../infra/http/index.js';
-import { createLogger, EnhancedLoggingConfig, Logger } from '../infra/logging/index.js';
-import { ServiceOrchestrator } from '../shared/utils/service-orchestrator.js';
 
-import type { Config, ConfigManager, TransportMode } from '../shared/types/index.js';
+import type { Config, ConfigManager, TransportMode } from '#shared/types/index.js';
+
+import { ConfigLoader } from '#infra/config/index.js';
+import { TransportRouter } from '#infra/http/index.js';
+import { createLogger, EnhancedLoggingConfig, Logger } from '#infra/logging/index.js';
+import { ServiceOrchestrator } from '#shared/utils/service-orchestrator.js';
 
 export interface RuntimeFoundation {
   logger: Logger;

--- a/server/src/runtime/data-loader.ts
+++ b/server/src/runtime/data-loader.ts
@@ -9,13 +9,13 @@ import * as path from 'node:path';
 
 import yaml from 'js-yaml';
 
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { ConfigLoader } from '#infra/config/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { PromptAssetManager } from '#modules/prompts/index.js';
+import type { Category, PromptData } from '#modules/prompts/types.js';
 import type { RuntimeLaunchOptions } from './options.js';
 import type { PathResolver } from './paths.js';
-import type { ConvertedPrompt } from '../engine/execution/types.js';
-import type { ConfigLoader } from '../infra/config/index.js';
-import type { Logger } from '../infra/logging/index.js';
-import type { PromptAssetManager } from '../modules/prompts/index.js';
-import type { Category, PromptData } from '../modules/prompts/types.js';
 
 export interface PromptDataLoadParams {
   logger: Logger;

--- a/server/src/runtime/framework-hot-reload.ts
+++ b/server/src/runtime/framework-hot-reload.ts
@@ -1,9 +1,10 @@
 // @lifecycle canonical - Builds framework hot-reload config for the hot-reload manager.
-import { createFrameworkHotReloadRegistration } from '../engine/frameworks/definitions/index.js';
 
-import type { Logger } from '../infra/logging/index.js';
-import type { McpToolRouter } from '../mcp/tools/index.js';
-import type { AuxiliaryReloadConfig } from '../modules/hot-reload/hot-reload-observer.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { McpToolRouter } from '#mcp/tools/index.js';
+import type { AuxiliaryReloadConfig } from '#modules/hot-reload/hot-reload-observer.js';
+
+import { createFrameworkHotReloadRegistration } from '#engine/frameworks/definitions/index.js';
 
 export function buildFrameworkAuxiliaryReloadConfig(
   logger: Logger,

--- a/server/src/runtime/gate-hot-reload.ts
+++ b/server/src/runtime/gate-hot-reload.ts
@@ -1,9 +1,10 @@
 // @lifecycle canonical - Builds gate hot-reload config for the hot-reload manager.
-import { createGateHotReloadRegistration } from '../engine/gates/hot-reload/index.js';
 
-import type { GateManager } from '../engine/gates/gate-manager.js';
-import type { Logger } from '../infra/logging/index.js';
-import type { AuxiliaryReloadConfig } from '../modules/hot-reload/hot-reload-observer.js';
+import type { GateManager } from '#engine/gates/gate-manager.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { AuxiliaryReloadConfig } from '#modules/hot-reload/hot-reload-observer.js';
+
+import { createGateHotReloadRegistration } from '#engine/gates/hot-reload/index.js';
 
 /**
  * Build gate auxiliary reload configuration for HotReloadObserver.

--- a/server/src/runtime/module-initializer.ts
+++ b/server/src/runtime/module-initializer.ts
@@ -10,37 +10,38 @@ import {
   initializeResourceChangeTracker,
   compareResourceBaseline,
 } from './resource-change-tracking.js';
-import { getDefaultRuntimeLoader } from '../engine/frameworks/definitions/runtime-framework-loader.js';
-import {
-  createFrameworkStateStore,
-  FrameworkStateStore,
-} from '../engine/frameworks/framework-state-store.js';
-import { createGateManager, GateManager } from '../engine/gates/gate-manager.js';
-import { createMetricsCollector } from '../infra/observability/metrics/index.js';
-import { ResourceChangeTracker } from '../infra/observability/tracking/index.js';
-import { createMcpToolsManager, McpToolRouter } from '../mcp/tools/index.js';
-import {
-  createToolDescriptionLoader,
-  ToolDescriptionLoader,
-} from '../mcp/tools/tool-description-loader.js';
-import { getDefaultStyleDefinitionLoader } from '../modules/formatting/core/style-definition-loader.js';
-import { isChainPrompt } from '../shared/utils/chainUtils.js';
 
-import type { RuntimeLaunchOptions } from './options.js';
-import type { PathResolver } from './paths.js';
-import type { ConvertedPrompt } from '../engine/execution/types.js';
-import type { ConfigLoader } from '../infra/config/index.js';
-import type { Logger } from '../infra/logging/index.js';
-import type { PromptAssetManager } from '../modules/prompts/index.js';
-import type { Category, PromptData } from '../modules/prompts/types.js';
-import type { ConversationStore } from '../modules/text-refs/conversation.js';
-import type { TextReferenceStore } from '../modules/text-refs/index.js';
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { ConfigLoader } from '#infra/config/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { PromptAssetManager } from '#modules/prompts/index.js';
+import type { Category, PromptData } from '#modules/prompts/types.js';
+import type { ConversationStore } from '#modules/text-refs/conversation.js';
+import type { TextReferenceStore } from '#modules/text-refs/index.js';
 import type {
   ResolvedFrameworkConfig,
   HookRegistryPort,
   McpNotificationEmitterPort,
-} from '../shared/types/index.js';
+} from '#shared/types/index.js';
+import type { RuntimeLaunchOptions } from './options.js';
+import type { PathResolver } from './paths.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import { getDefaultRuntimeLoader } from '#engine/frameworks/definitions/runtime-framework-loader.js';
+import {
+  createFrameworkStateStore,
+  FrameworkStateStore,
+} from '#engine/frameworks/framework-state-store.js';
+import { createGateManager, GateManager } from '#engine/gates/gate-manager.js';
+import { createMetricsCollector } from '#infra/observability/metrics/index.js';
+import { ResourceChangeTracker } from '#infra/observability/tracking/index.js';
+import { createMcpToolsManager, McpToolRouter } from '#mcp/tools/index.js';
+import {
+  createToolDescriptionLoader,
+  ToolDescriptionLoader,
+} from '#mcp/tools/tool-description-loader.js';
+import { getDefaultStyleDefinitionLoader } from '#modules/formatting/core/style-definition-loader.js';
+import { isChainPrompt } from '#shared/utils/chainUtils.js';
 
 export interface ModuleInitCallbacks {
   fullServerRefresh: () => Promise<void>;
@@ -209,7 +210,7 @@ export async function initializeModules(params: ModuleInitParams): Promise<Modul
   // Wire DatabasePort early so sub-handlers have it before first use
   if (serverRoot !== undefined && serverRoot !== '') {
     try {
-      const { SqliteEngine } = await import('../infra/database/sqlite-engine.js');
+      const { SqliteEngine } = await import('#infra/database/sqlite-engine.js');
       const dbManager = await SqliteEngine.getInstance(serverRoot, logger);
       await dbManager.initialize();
       mcpToolsManager.setDatabasePort(dbManager);
@@ -248,10 +249,10 @@ export async function initializeModules(params: ModuleInitParams): Promise<Modul
   // Index resources to SQLite for hook consumption (prompt-suggest, etc.)
   if (serverRoot !== undefined && serverRoot !== '') {
     try {
-      const { SqliteEngine } = await import('../infra/database/sqlite-engine.js');
-      const { createResourceIndexer } = await import('../infra/database/resource-indexer.js');
+      const { SqliteEngine } = await import('#infra/database/sqlite-engine.js');
+      const { createResourceIndexer } = await import('#infra/database/resource-indexer.js');
       const { ScriptToolDefinitionLoader } =
-        await import('../modules/automation/core/script-definition-loader.js');
+        await import('#modules/automation/core/script-definition-loader.js');
       const dbManager = await SqliteEngine.getInstance(serverRoot, logger);
       await dbManager.initialize();
       const resourcesDir = pathResolver?.getResourcesPath() ?? path.join(serverRoot, 'resources');

--- a/server/src/runtime/options.ts
+++ b/server/src/runtime/options.ts
@@ -11,7 +11,7 @@ import type {
   ClientFamily,
   IdentityLaunchDefaults,
   IdentityPolicyMode,
-} from '../shared/types/core-config.js';
+} from '#shared/types/core-config.js';
 
 /**
  * Path-related options parsed from CLI flags and environment variables

--- a/server/src/runtime/resource-change-tracking.ts
+++ b/server/src/runtime/resource-change-tracking.ts
@@ -8,18 +8,18 @@
 
 import * as path from 'node:path';
 
-import { ConfigLoader } from '../infra/config/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type {
+  AuxiliaryReloadConfig,
+  HotReloadEvent,
+} from '#modules/hot-reload/hot-reload-observer.js';
+
+import { ConfigLoader } from '#infra/config/index.js';
 import {
   createResourceChangeTracker,
   ResourceChangeTracker,
   TrackedResourceType,
-} from '../infra/observability/tracking/index.js';
-
-import type { Logger } from '../infra/logging/index.js';
-import type {
-  AuxiliaryReloadConfig,
-  HotReloadEvent,
-} from '../modules/hot-reload/hot-reload-observer.js';
+} from '#infra/observability/tracking/index.js';
 
 /**
  * Singleton tracker instance for the application

--- a/server/src/runtime/script-hot-reload.ts
+++ b/server/src/runtime/script-hot-reload.ts
@@ -1,12 +1,13 @@
 // @lifecycle canonical - Builds script tool hot-reload config for the hot-reload manager.
+
+import type { Logger } from '#infra/logging/index.js';
+import type { ScriptToolDefinitionLoader } from '#modules/automation/core/script-definition-loader.js';
+import type { AuxiliaryReloadConfig } from '#modules/hot-reload/hot-reload-observer.js';
+
 import {
   createScriptHotReloadRegistration,
   isScriptToolFile,
-} from '../modules/automation/hot-reload/index.js';
-
-import type { Logger } from '../infra/logging/index.js';
-import type { ScriptToolDefinitionLoader } from '../modules/automation/core/script-definition-loader.js';
-import type { AuxiliaryReloadConfig } from '../modules/hot-reload/hot-reload-observer.js';
+} from '#modules/automation/hot-reload/index.js';
 
 /**
  * Build script tool auxiliary reload configuration for HotReloadObserver.

--- a/server/src/runtime/startup-server.ts
+++ b/server/src/runtime/startup-server.ts
@@ -6,19 +6,19 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { createTransportRouter, startMcpServer, TransportRouter } from '../infra/http/index.js';
-import { createApiRouter } from '../mcp/http/api.js';
-
+import type { ConvertedPrompt } from '#engine/execution/types.js';
+import type { ConfigLoader } from '#infra/config/index.js';
+import type { ServerLifecycle } from '#infra/http/index.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { ApiRouter } from '#mcp/http/api.js';
+import type { McpToolRouter } from '#mcp/tools/index.js';
+import type { PromptAssetManager } from '#modules/prompts/index.js';
+import type { Category, PromptData } from '#modules/prompts/types.js';
+import type { TransportMode } from '#shared/types/index.js';
 import type { RuntimeLaunchOptions } from './options.js';
-import type { ConvertedPrompt } from '../engine/execution/types.js';
-import type { ConfigLoader } from '../infra/config/index.js';
-import type { ServerLifecycle } from '../infra/http/index.js';
-import type { Logger } from '../infra/logging/index.js';
-import type { ApiRouter } from '../mcp/http/api.js';
-import type { McpToolRouter } from '../mcp/tools/index.js';
-import type { PromptAssetManager } from '../modules/prompts/index.js';
-import type { Category, PromptData } from '../modules/prompts/types.js';
-import type { TransportMode } from '../shared/types/index.js';
+
+import { createTransportRouter, startMcpServer, TransportRouter } from '#infra/http/index.js';
+import { createApiRouter } from '#mcp/http/api.js';
 
 export interface ServerStartupParams {
   logger: Logger;

--- a/server/src/runtime/style-hot-reload.ts
+++ b/server/src/runtime/style-hot-reload.ts
@@ -1,9 +1,10 @@
 // @lifecycle canonical - Builds style hot-reload config for the hot-reload manager.
-import { createStyleHotReloadRegistration } from '../modules/formatting/hot-reload/index.js';
 
-import type { Logger } from '../infra/logging/index.js';
-import type { StyleManager } from '../modules/formatting/index.js';
-import type { AuxiliaryReloadConfig } from '../modules/hot-reload/hot-reload-observer.js';
+import type { Logger } from '#infra/logging/index.js';
+import type { StyleManager } from '#modules/formatting/index.js';
+import type { AuxiliaryReloadConfig } from '#modules/hot-reload/hot-reload-observer.js';
+
+import { createStyleHotReloadRegistration } from '#modules/formatting/hot-reload/index.js';
 
 /**
  * Build style auxiliary reload configuration for HotReloadObserver.

--- a/server/src/runtime/telemetry-lifecycle.ts
+++ b/server/src/runtime/telemetry-lifecycle.ts
@@ -9,16 +9,16 @@
  * AttributePolicyEnforcer, and TelemetryHookObserver. No embedded domain logic.
  */
 
-import { HookRegistry } from '../infra/hooks/index.js';
+import type { TelemetryStatus } from '#infra/observability/telemetry/index.js';
+import type { Logger, TelemetryConfig } from '#shared/types/index.js';
+
+import { HookRegistry } from '#infra/hooks/index.js';
 import {
   createTelemetryRuntime,
   TelemetryRuntimeImpl,
   AttributePolicyEnforcer,
   TelemetryHookObserver,
-} from '../infra/observability/telemetry/index.js';
-
-import type { TelemetryStatus } from '../infra/observability/telemetry/index.js';
-import type { Logger, TelemetryConfig } from '../shared/types/index.js';
+} from '#infra/observability/telemetry/index.js';
 
 export interface TelemetryLifecycleParams {
   config: TelemetryConfig;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -17,23 +17,20 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "outDir": "dist",
-    // Without rootDir, tsc infers the common source root as the package directory, so
-    // src/index.ts emitted to dist/src/index.d.ts while package.json advertised
-    // "types": "dist/index.d.ts" — a path that did not exist. The package shipped 405
-    // declaration files and no reachable entry, so TS consumers got none of them.
-    // It is also what TS2210 requires before a package.json "imports" map can resolve.
+    // Required before a package.json "imports" map can resolve: without it tsc reports
+    // TS2210 "the project root is ambiguous". It also pins the emit layout rather than
+    // letting tsc infer it from whichever files happen to be included.
     "rootDir": "./src",
     "sourceMap": true,
-    "declaration": true,
-    "resolveJsonModule": true,
-    "baseUrl": ".",
-    "paths": {
-      "@shared/*": ["src/shared/*"],
-      "@infra/*": ["src/infra/*"],
-      "@engine/*": ["src/engine/*"],
-      "@modules/*": ["src/modules/*"],
-      "@mcp/*": ["src/mcp/*"]
-    }
+    // No `declaration`. This package ships a server binary and Python hooks, not a
+    // library: nothing imports it (`.mcpbignore` excludes server/src from the extension,
+    // manifest.json points at dist/index.js, and neither downstream plugin has a single
+    // `import ... from 'claude-prompts'`). Emitting 405 unread .d.ts files on every build
+    // is what created the broken "types" entry this replaced.
+    "resolveJsonModule": true
+    // No `paths`. Subpath imports are declared once in package.json "imports", which
+    // tsc, esbuild, Jest and Node all resolve natively — instead of the same map
+    // maintained in tsconfig, esbuild.config.mjs and jest.config.cjs.
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
Two commits: a declared API contract, then the import migration it makes safe.

## `docs: declare the public API contract`

`CONTRIBUTING.md` explained **how** to mark a breaking change but nothing said **what counts** as one. With no declared surface, "breaking" defaults to whatever feels significant, so majors inflate until the number stops carrying information — and each one forces a dependency-range bump in `gemini-prompts` and `opencode-prompts`, both still pinned `^2.0.0`.

| In the contract — bump major | Outside it — change freely |
|---|---|
| MCP tool names, parameters, response shape | Internal TypeScript exports |
| `claude-prompts` / `cpm` CLI commands and flags | `package.json` packaging fields |
| Prompt/gate/methodology YAML, `config.json` | `src/` layout and import style |
| Python hook contract the plugins consume | Build tooling, CI, validation scripts |
| Symbolic command language (`>>`, `==>`) | Which files land in the tarball |

## `refactor(server): migrate cross-layer imports to package.json subpath imports`

**614 cross-layer relative imports → `#`-prefixed subpath specifiers.** A `../../` chain encodes the importer's depth into the specifier, so moving a file silently changes what it means. `#shared/x.js` names the layer and survives the move. The 972 intra-layer relative imports are deliberately untouched — `./foo.js` says "next to me", which is information.

**One map instead of three.** The five `@`-aliases lived in `tsconfig`, `esbuild.config.mjs` *and* `jest.config.cjs`, and were used zero times. Node's `imports` field is resolved natively by tsc, esbuild, Jest, dependency-cruiser and Node.

**Packaging follows what this actually is** — a server binary, `cpm` CLI and Python hooks, not a library. `src/index.ts` exports four symbols, all server lifecycle. `types`, `exports["."].types`, declaration emit and `src` in `files` are removed; tarball drops 5.1 MB / 1029 files → 4.2 MB / 198 files.

Not breaking under the contract above: the MCP surface, CLI, resource formats and hook contract are untouched. The `types` entry resolved at all only in 3.0.0, as an unintended side effect of the `rootDir` fix, and no consumer imports this package.

## Enforcement

`validate:no-crosslayer-relative` (new, in `validate:all`), **not** ESLint `no-restricted-imports` — a textual `../../*` ban flagged **197 legitimate deep intra-layer imports and zero real violations**. Whether an import crosses a layer is a question about the *resolved* path, which is why the migration used ts-morph rather than sed.

That guard immediately caught a gap in the codemod: 10 surviving cross-layer imports as inline `import('…')` **type nodes**, which are neither import declarations nor dynamic-import calls.

## Verification

| Check | Result |
|---|---|
| typecheck / build | 0 / 0 |
| Jest | 1732 / 1732 |
| dependency-cruiser | 608 `#` edges, **0 unresolvable** |
| `verify:mcp` | 11 / 11 against a live server from the new bundle |
| `cpm` CLI (reaches into `server/src` cross-package) | typecheck 0, build 0, 75 / 75 |
| `validate:all` | 0 (28 members) |
| ratchet | 3475, below the 3477 baseline |

Release-please will read these as `docs` + `refactor` → **no version bump**, leaving the release for the in-flight work to cut.
