### PR TITLE
fix(scripts): check gemini's dependency range, not its own version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -139,11 +139,16 @@
       matchPackageNames: ["zod"],
       allowedVersions: "<4.0.0",
     },
-    {
-      description: "Hold express at v4.x until LLM ecosystem catches up to v5",
-      matchPackageNames: ["express", "@types/express"],
-      allowedVersions: "<5.0.0",
-    },
+    // The express <5.0.0 hold was removed on 2026-08-01. It was dead config contradicted
+    // by the repo it governed: server/package.json already declares express ^5.2.1 and
+    // @types/express ^5.0.6, and @modelcontextprotocol/sdk itself depends on express
+    // ^5.2.1. The migration the hold existed to defer had already happened, so all the
+    // rule still did was block v5.x PATCH updates — including any security fix.
+    //
+    // The zod hold below stays: the SDK now accepts ^3.25 || ^4.0, so the stated reason
+    // is satisfied at the boundary, but 16 files import zod (several are the hand-written
+    // MCP parameter schemas that are the validation SSOT). That is a migration, not a
+    // version bump, and it is tracked in its own plan rather than lifted here.
   ],
 
   // Vulnerability alerts

--- a/server/scripts/validate-versions.js
+++ b/server/scripts/validate-versions.js
@@ -117,6 +117,36 @@ const assertMarketplaceSource = (source) => {
   }
 };
 
+/**
+ * Assert a downstream repo's `claude-prompts` range still covers the version we ship.
+ *
+ * Downstream repos own their own version numbers; what has to stay true is that their
+ * dependency range admits ours. Two consumers now (gemini, opencode), so the major-match
+ * lives here rather than being copied per check.
+ *
+ * Known constraint: only the `^MAJOR.` form is accepted. A pinned exact version is
+ * rejected even when it does cover us, because the sync-downstream job always writes a
+ * caret range — anything else means the range stopped being generated and should be
+ * looked at. Widen this only alongside a downstream that legitimately pins.
+ */
+const assertDependencyRange = (label, dependencies) => {
+  const dep = dependencies?.['claude-prompts'];
+  if (!dep) {
+    throw new Error(`${label} missing claude-prompts dependency`);
+  }
+  const majorMatch = dep.match(/\^(\d+)\./);
+  if (!majorMatch) {
+    throw new Error(`${label} dependency range unexpected format: ${dep}`);
+  }
+  const depMajor = parseInt(majorMatch[1], 10);
+  const coreMajor = parseInt(coreVersion.split('.')[0], 10);
+  if (depMajor !== coreMajor) {
+    throw new Error(
+      `${label} dependency ${dep} does not cover ${coreVersion} (major mismatch: ${depMajor} vs ${coreMajor})`
+    );
+  }
+};
+
 const distributionChecks = [
   {
     label: 'minipuft-plugins marketplace',
@@ -131,30 +161,23 @@ const distributionChecks = [
     },
   },
   {
-    label: 'gemini-prompts gemini-extension.json',
-    url: 'https://raw.githubusercontent.com/minipuft/gemini-prompts/main/gemini-extension.json',
-    validate: (data) => assertVersion('Gemini extension', data.version),
+    // Checks gemini's DEPENDENCY RANGE, not gemini-extension.json's own version.
+    // This previously asserted `gemini-extension.json.version === coreVersion`, which
+    // contradicted the documented decision that release-please owns that number
+    // downstream (see extension-publish.yml, sync-downstream closing comment). gemini is
+    // at 1.3.2 while we ship 3.0.1, so the check could only ever fail — it never fired
+    // because downstream-sync.yml runs on repository_dispatch and has zero runs.
+    // gemini-extension.json carries no reference to our version at all; it invokes
+    // `npx claude-prompts`, so the range in package.json is the only real coupling.
+    label: 'gemini-prompts dependency',
+    url: 'https://raw.githubusercontent.com/minipuft/gemini-prompts/main/package.json',
+    validate: (data) => assertDependencyRange('gemini-prompts', data.dependencies),
   },
   {
     label: 'opencode-prompts dependency',
     url: 'https://raw.githubusercontent.com/minipuft/opencode-prompts/main/package.json',
     validate: (data) => {
-      const dep = data.dependencies?.['claude-prompts'];
-      if (!dep) {
-        throw new Error('OpenCode package missing claude-prompts dependency');
-      }
-      // Check that the semver range covers the current version (^MAJOR.0.0)
-      const majorMatch = dep.match(/\^(\d+)\./);
-      if (!majorMatch) {
-        throw new Error(`OpenCode dependency range unexpected format: ${dep}`);
-      }
-      const depMajor = parseInt(majorMatch[1], 10);
-      const coreMajor = parseInt(coreVersion.split('.')[0], 10);
-      if (depMajor !== coreMajor) {
-        throw new Error(
-          `OpenCode dependency ${dep} does not cover ${coreVersion} (major mismatch: ${depMajor} vs ${coreMajor})`
-        );
-      }
+      assertDependencyRange('opencode-prompts', data.dependencies);
     },
   },
 ];


### PR DESCRIPTION
## A check that could never pass, in a workflow that never runs

`validate-versions.js --distribution` asserted:

```js
label: 'gemini-prompts gemini-extension.json',
validate: (data) => assertVersion('Gemini extension', data.version),   // === coreVersion
```

That contradicts the decision recorded in `extension-publish.yml`'s own closing comment:

> `gemini-extension.json`'s own version is NOT synced — release-please owns it downstream.

gemini is at **1.3.2**; we ship **3.0.1**. The check could only ever fail. It never fired because `downstream-sync.yml` triggers on `repository_dispatch: downstream-release`, which has **zero runs** in the repo's history.

## The right coupling

`gemini-extension.json` contains no reference to our version at all — it invokes `npx claude-prompts`. The only real coupling is `package.json`'s dependency range, exactly as for opencode. So the check now targets that, and the major-match is extracted into a shared `assertDependencyRange()` rather than copied, now that there are two consumers.

## Verified falsifiable, not just green

Replacing a can-never-pass check with a can-never-fail one would be no better, so the shared assert was probed against wrong inputs:

```
  ok   covers (^3.0.0)        -> accepted
  ok   stale major (^2.0.0)   -> rejected
  ok   future major (^4.0.0)  -> rejected
  ok   pinned exact (3.0.1)   -> rejected
  ok   missing dep            -> rejected
```

The pinned-exact rejection is deliberate and documented in the function: `sync-downstream` always writes a caret range, so anything else means range generation stopped and deserves a look.

Live run against all three downstream repos:

```
Distribution Check:
  ✅ minipuft-plugins marketplace
  ✅ gemini-prompts dependency
  ✅ opencode-prompts dependency
```

## Also: removes the Renovate `express` hold

```json5
{ description: "Hold express at v4.x until LLM ecosystem catches up to v5",
  matchPackageNames: ["express", "@types/express"], allowedVersions: "<5.0.0" }
```

Dead config, contradicted by the repo it governed:

| | |
|---|---|
| `server/package.json` | `"express": "^5.2.1"` |
| | `"@types/express": "^5.0.6"` |
| `@modelcontextprotocol/sdk` | depends on `express: ^5.2.1` |

The migration it existed to defer already happened. All the rule still did was block v5.x **patch** updates — including any security fix.

**The `zod` hold stays.** The SDK now accepts `^3.25 || ^4.0`, so the stated reason is satisfied at the boundary — but 16 files import zod, several being the hand-written MCP parameter schemas that `.claude/rules/mcp-contracts.md` names as the validation SSOT. That is a migration, and it is tracked in its own plan.

## Verification

- `prettier --check` clean on both files; renovate.json5 parses as JSON5
- `lint:ratchet` — OK: 3475 errors, 1434 warnings (no regressions)
- distribution checks run live against all three downstream repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBvV2djJzY2YAKG3tPjMED