### PR TITLE
fix(deps): align Renovate with delivery contracts

### DIFF
--- a/.github/actions/setup-node-install/action.yml
+++ b/.github/actions/setup-node-install/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: Setup Node.js (version)
       if: ${{ inputs.node-version != '' && inputs.registry-url == '' }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}
@@ -60,7 +60,7 @@ runs:
 
     - name: Setup Node.js (version with registry)
       if: ${{ inputs.node-version != '' && inputs.registry-url != '' }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
@@ -69,7 +69,7 @@ runs:
 
     - name: Setup Node.js (version file)
       if: ${{ inputs.node-version-file != '' && inputs.registry-url == '' }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: ${{ inputs.node-version-file }}
         cache: ${{ inputs.cache }}
@@ -77,7 +77,7 @@ runs:
 
     - name: Setup Node.js (version file with registry)
       if: ${{ inputs.node-version-file != '' && inputs.registry-url != '' }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: ${{ inputs.node-version-file }}
         registry-url: ${{ inputs.registry-url }}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,15 +2,15 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   description: "Renovate Bot configuration for automated dependency updates",
 
-  // Extend from recommended presets
+  // Start from Renovate's recommended policy, then opt into the targeted parts of
+  // config:best-practices that match this repository's release and support model.
   extends: [
     "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits",
+    ":configMigration",
+    "helpers:pinGitHubActionDigests",
+    "abandonments:recommended",
     ":preserveSemverRanges",
-    "group:monorepos",
-    "group:recommended",
-    "workarounds:all",
+    ":maintainLockFilesWeekly",
   ],
 
   // Repository-specific settings
@@ -25,17 +25,28 @@
   prCreation: "immediate",
   prHourlyLimit: 2,
 
+  // Regular updates run in a six-hour hosted-app window. Vulnerability alerts
+  // override this schedule below.
+  schedule: ["* 0-5 * * 1"],
+
   // Auto-merge configuration
   platformAutomerge: false,
   automerge: false,
   automergeType: "pr",
   automergeStrategy: "squash",
 
-  // PR title and body formatting
-  commitMessagePrefix: "chore(deps):",
+  // PR title and body formatting. Server runtime dependencies are overridden to
+  // `fix` below because Release Please treats them as patch-release inputs.
+  semanticCommits: "enabled",
+  semanticCommitType: "chore",
+  semanticCommitScope: "deps",
   commitMessageAction: "update",
   commitMessageTopic: "{{depName}}",
   commitMessageExtra: "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{newValue}}{{/if}}{{/if}}{{/if}}",
+
+  // Keep one repository label on every dependency PR. Matched rules append only
+  // labels that exist in the repository.
+  labels: ["dependencies"],
 
   // Package file detection: no `enabledManagers` allowlist on purpose.
   // This config was inert until 2026-07-31, so its `["npm"]` allowlist had never
@@ -44,51 +55,34 @@
   // `github-actions` manager. Auto-detection is what has actually been running; keep it.
   packageRules: [
     {
-      description: "Security updates - immediate and auto-merge",
-      matchUpdateTypes: ["patch"],
-      matchDepTypes: ["dependencies", "devDependencies"],
-      matchCurrentVersion: "!/^0/",
-      automerge: false,
-      schedule: ["at any time"],
-      labels: ["dependencies", "security", "auto-merge"],
-      groupName: "Security patches",
+      description: "Default dependency PRs remain maintenance-only",
+      matchPackageNames: ["*"],
+      semanticCommitType: "chore",
     },
     {
-      description: "Production dependencies - patch and minor updates",
+      description: "Server runtime dependencies trigger patch releases",
+      matchFileNames: ["server/package.json"],
+      matchDepTypes: ["dependencies"],
+      semanticCommitType: "fix",
+    },
+    {
+      description: "Group nonbreaking server runtime updates",
+      matchFileNames: ["server/package.json"],
       matchDepTypes: ["dependencies"],
       matchUpdateTypes: ["minor", "patch"],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "production", "auto-merge"],
-      groupName: "Production dependencies (minor & patch)",
+      groupName: "Server runtime dependencies",
     },
     {
-      description: "Production dependencies - major updates",
-      matchDepTypes: ["dependencies"],
+      description: "Group nonbreaking development updates",
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "Development dependencies",
+    },
+    {
+      description: "Isolate major updates for manual review",
       matchUpdateTypes: ["major"],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "production", "major-update", "needs-review"],
-      groupName: "Production dependencies (major)",
+      groupName: null,
       reviewers: ["minipuft"],
-    },
-    {
-      description: "Dev dependencies - patch and minor updates",
-      matchDepTypes: ["devDependencies"],
-      matchUpdateTypes: ["minor", "patch"],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "dev", "auto-merge"],
-      groupName: "Dev dependencies (minor & patch)",
-    },
-    {
-      description: "Dev dependencies - major updates",
-      matchDepTypes: ["devDependencies"],
-      matchUpdateTypes: ["major"],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "dev", "major-update", "needs-review"],
-      groupName: "Dev dependencies (major)",
     },
     {
       // No `allowedVersions` pin here on purpose. Both holds this file used to carry were
@@ -98,10 +92,8 @@
       // rather than in a plan file nobody opens during review.
       description: "TypeScript - require manual review",
       matchPackageNames: ["typescript"],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "typescript", "needs-review"],
       reviewers: ["minipuft"],
+      groupName: "TypeScript",
       prBodyNotes: [
         "### TypeScript 7 is BLOCKED — close this PR unless all three boxes tick",
         "",
@@ -119,38 +111,37 @@
     {
       description: "MCP SDK - critical dependency",
       matchPackageNames: ["@modelcontextprotocol/sdk"],
-      automerge: false,
       schedule: ["at any time"],
-      labels: ["dependencies", "mcp-sdk", "critical", "needs-review"],
       reviewers: ["minipuft"],
-      groupName: "MCP SDK updates",
+      groupName: "MCP SDK",
     },
     {
       description: "Testing frameworks - require validation",
-      matchPackageNames: ["jest", "ts-jest", "@types/jest"],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "testing", "needs-review"],
-      groupName: "Testing framework updates",
+      matchPackageNames: ["jest", "ts-jest", "@types/jest", "@jest/**"],
+      groupName: "Testing frameworks",
     },
     {
       description: "ESLint and Prettier - require validation",
       matchPackageNames: [
         "eslint",
         "prettier",
-        "@typescript-eslint/eslint-plugin",
-        "@typescript-eslint/parser",
+        "@eslint/**",
+        "typescript-eslint",
+        "eslint-config-*",
+        "eslint-plugin-*",
       ],
-      automerge: false,
-      schedule: ["before 3am on Monday"],
-      labels: ["dependencies", "linting", "needs-review"],
       groupName: "Linting and formatting tools",
     },
     {
-      description: "Vulnerability fixes - high priority",
-      matchUpdateTypes: ["patch", "minor"],
-      isVulnerabilityAlert: true,
-      prPriority: 10,
+      description: "GitHub Actions - one executable supply-chain boundary",
+      matchManagers: ["github-actions"],
+      groupName: "GitHub Actions",
+    },
+    {
+      description: "Pinned Python validation tools",
+      matchDatasources: ["pypi"],
+      matchPackageNames: ["ruff", "pyrefly"],
+      groupName: "Python validation tools",
     },
     // The zod <4.0.0 hold was removed on 2026-08-01, together with the migration it was
     // deferring. What satisfied it: @modelcontextprotocol/sdk 1.30.0 accepts ^3.25 || ^4.0,
@@ -175,19 +166,20 @@
   // Vulnerability alerts
   // Renovate is the sole remediation path since Dependabot security updates were
   // disabled (2026-07-31). Dependabot *alerts* stay on — Renovate reads that feed
-  // to populate these. `minimumReleaseAge: 0` overrides the global 3-day soak,
+  // to populate these. `minimumReleaseAge: null` overrides the global 3-day soak,
   // which would otherwise delay every CVE fix by three days.
   vulnerabilityAlerts: {
-    labels: ["security", "vulnerability"],
+    enabled: true,
     automerge: false,
     schedule: ["at any time"],
     minimumReleaseAge: null,
+    addLabels: ["security", "vulnerability"],
   },
 
   // Dependency dashboard
   dependencyDashboard: true,
   dependencyDashboardTitle: "📦 Dependency Updates Dashboard",
-  dependencyDashboardHeader: "This dashboard tracks all pending dependency updates. Security updates are processed immediately, while regular updates run Monday mornings.",
+  dependencyDashboardHeader: "This dashboard tracks all pending dependency updates. Vulnerability alerts run immediately; regular updates and lock maintenance run Mondays from 00:00 through 05:59 UTC.",
   dependencyDashboardApproval: false,
 
   // Stability - wait for package to stabilize (renamed from stabilityDays)
@@ -201,10 +193,9 @@
   // Lockfile maintenance
   lockFileMaintenance: {
     enabled: true,
-    schedule: ["before 3am on the first day of the month"],
+    schedule: ["* 0-5 * * 1"],
     automerge: false,
     commitMessageAction: "refresh",
-    labels: ["dependencies", "lockfile-maintenance"],
   },
 
   // PR body template
@@ -215,32 +206,43 @@
   branchPrefix: "renovate/",
   branchConcurrentLimit: 10,
 
-  // Respect package.json version ranges
-  rangeStrategy: "auto",
   respectLatest: true,
 
   // Tool versions pinned inside workflow `run:` steps are invisible to every built-in
-  // manager — nothing parses a shell line. Leaving them unpinned is the alternative, and
-  // that is what turned an untouched branch red on 2026-07-31 when `pip install pyrefly`
-  // silently moved 0.55.x -> 1.1.1. These two regexes are what make pinning sustainable
-  // rather than a version that rots because no one is watching it.
+  // manager — nothing parses a shell line. MCPB is deliberately absent here because its
+  // exact root devDependency is the sole update path. The three remaining workflow tools
+  // need exact regex managers so their pins stay maintainable.
   customManagers: [
     {
       customType: "regex",
-      description: "Pinned PyPI tools installed in workflow run steps",
-      managerFilePatterns: ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      description: "Pinned Ruff version in the CI workflow",
+      managerFilePatterns: ["/^\\.github\\/workflows\\/ci\\.yml$/"],
       matchStrings: [
-        "pip install (?<depName>[a-zA-Z0-9._-]+)==(?<currentValue>[0-9][^\\s\"']*)",
+        "run: pip install ruff==(?<currentValue>[0-9][^\\s\"']*) --quiet",
       ],
+      depNameTemplate: "ruff",
       datasourceTemplate: "pypi",
     },
     {
       customType: "regex",
-      description: "Pinned npm tools installed globally in workflow run steps",
-      managerFilePatterns: ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      description: "Pinned Pyrefly version in the CI workflow",
+      managerFilePatterns: ["/^\\.github\\/workflows\\/ci\\.yml$/"],
       matchStrings: [
-        "npm install -g (?<depName>@?[a-zA-Z0-9._/-]+)@(?<currentValue>[0-9][^\\s\"']*)",
+        "run: pip install pyrefly==(?<currentValue>[0-9][^\\s\"']*) --quiet",
       ],
+      depNameTemplate: "pyrefly",
+      datasourceTemplate: "pypi",
+    },
+    {
+      customType: "regex",
+      description: "Pinned Renovate version in its validator workflow",
+      managerFilePatterns: [
+        "/^\\.github\\/workflows\\/renovate-config-validator\\.yml$/",
+      ],
+      matchStrings: [
+        "npm install -g renovate@(?<currentValue>[0-9][^\\s\"']*)",
+      ],
+      depNameTemplate: "renovate",
       datasourceTemplate: "npm",
     },
   ],

--- a/.github/required-contexts.json
+++ b/.github/required-contexts.json
@@ -9,7 +9,7 @@
     "`npm run validate:required-contexts` (in validate:all) fails when an entry below no longer",
     "matches a job `name:` in .github/workflows/, so a rename breaks CI instead of merges.",
     "Applying this list to the branch is a separate, deliberate step:",
-    "  jq -r '.contexts[]' .github/required-contexts.json |",
+    "  jq '{strict: true, contexts}' .github/required-contexts.json |",
     "  gh api -X PATCH repos/minipuft/claude-prompts/branches/main/protection/required_status_checks \\",
     "    --input -"
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_LTS }}
           cache: npm
@@ -64,9 +64,13 @@ jobs:
       # ruff is installed here rather than via astral-sh/ruff-action because
       # `validate:python` (inside validate:all) is the single definition of the Python
       # gate — the action would have been a second, silently divergent one.
-      - name: Install pinned Python tooling
+      - name: Install Ruff
         working-directory: .
-        run: pip install ruff==0.16.0 pyrefly==1.1.1 --quiet
+        run: pip install ruff==0.16.0 --quiet
+
+      - name: Install Pyrefly
+        working-directory: .
+        run: pip install pyrefly==1.1.1 --quiet
 
       # The seven `validate:no-*` recurrence guards shell out to ripgrep, which the
       # GitHub runner image does not ship. This was latent until validate:all started
@@ -98,10 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
           cache: npm
@@ -140,10 +144,10 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_LTS }}
           cache: npm
@@ -168,7 +172,7 @@ jobs:
         run: npm run validate:tool-schemas
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: server/dist/
@@ -186,19 +190,19 @@ jobs:
     strategy:
       fail-fast: false
       # 24 is what actually ships: every publish path (npm, extension) reads
-      # .node-version, which is 24. Testing only 22.x meant a Node-24-specific regression
-      # passed CI and shipped. 22.x stays because engines.node is ">=22.0.0".
+      # .node-version, which is 24. Testing only the minimum meant a Node-24-specific
+      # regression passed CI and shipped. 22.13.0 proves the declared node:sqlite floor.
       matrix:
-        node: ["22.x", "24"]
+        node: ["22.13.0", "24"]
     defaults:
       run:
         working-directory: server
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -208,7 +212,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: server/dist/
@@ -218,7 +222,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Coverage threshold check
-        if: matrix.node == '22.x'
+        if: matrix.node == '22.13.0'
         run: npm run test:coverage
         timeout-minutes: 15
 
@@ -264,7 +268,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -279,7 +283,7 @@ jobs:
           fi
 
       - name: Comment PR with results
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           LINT_RESULT: ${{ needs.lint.result }}
           CLI_RESULT: ${{ needs.cli.result }}

--- a/.github/workflows/downstream-sync.yml
+++ b/.github/workflows/downstream-sync.yml
@@ -18,9 +18,9 @@ jobs:
           echo "version=${{ github.event.client_payload.version }}" >> "$GITHUB_OUTPUT"
           echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
           cache: npm

--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -25,17 +25,19 @@ jobs:
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # For workflow_run: use the branch/tag from the triggering workflow
           # For workflow_dispatch: use current ref
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
           cache: npm
-          cache-dependency-path: server/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            server/package-lock.json
 
       - name: Extract version
         id: version
@@ -71,14 +73,11 @@ jobs:
         working-directory: server
         run: npm ci
 
-      - name: Build server
-        working-directory: server
-        run: npm run build
+      - name: Install root packaging tools
+        run: npm ci --ignore-scripts
 
       - name: Build Desktop Extension (.mcpb)
-        run: |
-          chmod +x scripts/build-extension.sh
-          ./scripts/build-extension.sh
+        run: npm --prefix server run pack:mcpb
 
       - name: Rename with version
         run: |
@@ -86,7 +85,7 @@ jobs:
 
       - name: Upload to Release
         if: github.event_name == 'workflow_run'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: claude-prompts-${{ steps.version.outputs.version }}.mcpb
           # Match Release Please tag format (include-component-in-tag: false)
@@ -94,7 +93,7 @@ jobs:
 
       - name: Upload Artifact (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: claude-prompts-${{ steps.version.outputs.version }}.mcpb
           path: claude-prompts-${{ steps.version.outputs.version }}.mcpb
@@ -110,11 +109,11 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       artifact-name: dist-runtime-${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
           cache: npm
@@ -191,7 +190,7 @@ jobs:
           test -f "$VERIFY_DIR/agents/chain-executor.md"
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-runtime-${{ steps.version.outputs.version }}
           path: ${{ runner.temp }}/dist-runtime.tar.gz
@@ -205,12 +204,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-runtime-${{ needs.plugin-dist.outputs.version }}
           path: ${{ runner.temp }}/dist-artifact
@@ -272,7 +271,7 @@ jobs:
             name: opencode
     steps:
       - name: Checkout upstream (for version)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           path: upstream
@@ -290,7 +289,7 @@ jobs:
           echo "license=$license" >> $GITHUB_OUTPUT
 
       - name: Checkout downstream
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ matrix.repo }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -299,7 +298,7 @@ jobs:
       # This job now runs npm (lockfile regeneration + the npm ci assertion below), so the
       # Node/npm version must be pinned rather than inherited from whatever the runner ships —
       # lockfileVersion differs across npm majors and would churn the downstream diff.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: upstream/.node-version
 
@@ -412,7 +411,7 @@ jobs:
 
       - name: Create PR
         id: create-pr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: downstream
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -439,11 +438,11 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
           cache: npm
@@ -516,7 +515,7 @@ jobs:
 
       - name: Upload to Release
         if: github.event_name == 'workflow_run'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: claude-prompts-plugin-${{ steps.version.outputs.version }}.zip
           # Match Release Please tag format (include-component-in-tag: false)
@@ -524,7 +523,7 @@ jobs:
 
       - name: Upload Artifact (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: claude-prompts-plugin-${{ steps.version.outputs.version }}.zip
           path: claude-prompts-plugin-${{ steps.version.outputs.version }}.zip

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           # Use PAT to allow releases to trigger downstream workflows (npm-publish).
           # Falls back to github.token for forks (but won't trigger workflow-to-workflow).
@@ -34,7 +34,7 @@ jobs:
 
       - name: Checkout repo
         if: steps.release.outputs.pr && steps.release.outputs.release_created != 'true'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           fetch-depth: 0

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -4,11 +4,33 @@ on:
   push:
     paths:
       - ".github/renovate.json5"
-      - ".github/workflows/renovate-config-validator.yml"
+      - ".github/actions/**/*.yml"
+      - ".github/actions/**/*.yaml"
+      - ".github/workflows/**/*.yml"
+      - ".github/workflows/**/*.yaml"
+      - ".node-version"
+      - "package.json"
+      - "package-lock.json"
+      - "cli/package.json"
+      - "server/package.json"
+      - "server/package-lock.json"
+      - "server/.npmrc"
+      - "server/scripts/validate-renovate-extraction.js"
   pull_request:
     paths:
       - ".github/renovate.json5"
-      - ".github/workflows/renovate-config-validator.yml"
+      - ".github/actions/**/*.yml"
+      - ".github/actions/**/*.yaml"
+      - ".github/workflows/**/*.yml"
+      - ".github/workflows/**/*.yaml"
+      - ".node-version"
+      - "package.json"
+      - "package-lock.json"
+      - "cli/package.json"
+      - "server/package.json"
+      - "server/package-lock.json"
+      - "server/.npmrc"
+      - "server/scripts/validate-renovate-extraction.js"
 
 jobs:
   validate-config:
@@ -17,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: ".node-version"
 
@@ -28,7 +50,18 @@ jobs:
       # two runs of an unchanged file. Renovate proposes its own bumps here via the
       # customManagers regex in .github/renovate.json5.
       - name: Install Renovate
-        run: npm install -g renovate@44.5.2
+        run: npm install -g renovate@44.6.0
 
       - name: Validate Renovate config
         run: renovate-config-validator --strict .github/renovate.json5
+
+      - name: Validate resolved policy and extraction
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+        run: |
+          extraction="$RUNNER_TEMP/renovate-extraction.jsonl"
+          if ! LOG_FORMAT=json LOG_LEVEL=debug renovate --platform=local --dry-run=extract --print-config > "$extraction" 2>&1; then
+            cat "$extraction"
+            exit 1
+          fi
+          node server/scripts/validate-renovate-extraction.js < "$extraction"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
 
+- **Dependency delivery contract:** Renovate now preserves semantic release types, validates extraction, uses the committed MCPB resolution path, and limits future automerge to observed low-risk development updates.
+- **Supply-chain controls:** GitHub Actions use immutable full commit SHAs with readable release comments, backed by a repository validator.
+- **Runtime support:** The server and desktop extension require Node.js >=22.13.0; server CI covers 22.13.0 and 24, the standalone CPM CLI remains >=18.18.0, and local/publish tooling uses Node 24.
 
 ## [2.1.0](https://github.com/minipuft/claude-prompts/compare/v2.0.0...v2.1.0) (2026-03-19)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,15 @@ git commit -m "feat(server): add new capability"
 
 ## Development Environment
 
-| Requirement | Version           | Notes                              |
-| ----------- | ----------------- | ---------------------------------- |
-| **Node.js** | 18 -- 24          | `.node-version` pinned to 24       |
-| **npm**     | Bundled with Node | Run `npm install` inside `server/` |
-| **Git**     | Any recent        | Required for Husky hooks           |
+| Surface / requirement                | Version           | Notes                                         |
+| ------------------------------------ | ----------------- | --------------------------------------------- |
+| **MCP server and desktop extension** | Node.js >=22.13.0 | CI tests the minimum and Node 24              |
+| **Standalone CPM CLI runtime**       | Node.js >=18.18.0 | Separate self-contained compatibility surface |
+| **Local development and publishing** | Node.js 24        | `.node-version` is the repository pin         |
+| **npm**                              | Bundled with Node | Run `npm install` inside `server/`            |
+| **Git**                              | Any recent        | Required for Husky hooks                      |
+
+The server uses `node:sqlite` without an experimental flag, which sets its runtime floor. Use Node 24 for repository development so local builds match the publish workflows.
 
 <details>
 <summary><strong>Repo Structure</strong></summary>

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -107,11 +107,11 @@ Found 2026-07-28 while authoring a prompt with `inline_gate_definitions`. All re
 - [x] Add a lint ratchet strategy: keep `tests/**` excluded initially, fail CI on new violations (`server/.eslint-ratchet-baseline.json`), and tighten scope once baseline is reduced.
 - [x] Align core CI gates with server scripts: `npm run typecheck` + `npm run lint:ratchet` + tests in CI/PR workflows.
 - [x] Ensure build output is exercised in CI: run `npm run build` and `npm run start:test` across the Node matrix.
-- [x] Add toolchain pinning for developers: commit `.nvmrc` + `.node-version` aligned with `server/package.json#engines`.
+- [x] Add toolchain pinning for developers: commit `.node-version` for the Node 24 development and publish toolchain.
 - [x] Align rule docs with the new workflow: update `AGENTS.md` and `CLAUDE.md` to match scripts, docs taxonomy, and the ESLint ratchet approach.
 - [ ] Ensure PR workflows run the architecture gates: `npm run validate:arch` and decide whether warnings should fail the build once cycles are resolved.
 - [x] Ensure generated artifacts stay in sync in CI: `npm run validate:contracts` and `npm run validate:metadata`.
-- [x] Decide support policy and enforce via CI matrix (Node versions / OS): CI verifies Node 18→24 on `ubuntu-latest`. (OS matrix can be added later if scripts are made cross-platform.)
+- [x] Decide support policy and enforce via CI matrix (Node versions / OS): server CI verifies Node 22.13.0 and 24 on `ubuntu-latest`; the standalone CLI runtime remains >=18.18.0. (An OS matrix can be added later if scripts are made cross-platform.)
 
 ### Test Modernization
 

--- a/docs/guides/identity-scope.md
+++ b/docs/guides/identity-scope.md
@@ -5,7 +5,7 @@ This guide shows you how to isolate state per workspace or organization when dep
 ## Prerequisites
 
 - Claude Prompts MCP server v1.7+
-- Node.js >= 22 (required for native SQLite)
+- Node.js >= 22.13.0 (required for unflagged native SQLite)
 - Understanding of your deployment transport (STDIO vs streamable-HTTP)
 
 ## How It Works

--- a/docs/portfolio/design-decisions.md
+++ b/docs/portfolio/design-decisions.md
@@ -22,7 +22,7 @@ The system is an **unopinionated engine for composability**:
 
 | Aspect            | Decision                 | Rationale                                                                                          |
 | ----------------- | ------------------------ | -------------------------------------------------------------------------------------------------- |
-| **Runtime**       | Node.js (v18+)           | I/O-bound workload (file watching, hot-reload). Mature `fs` ecosystem.                             |
+| **Runtime**       | Node.js (>=22.13.0)      | The server uses `node:sqlite` without an experimental flag; CI proves the minimum and Node 24.     |
 | **Language**      | TypeScript (strict mode) | Enables contract-driven development. Zod schemas bridge deterministic runtime ↔ probabilistic LLM. |
 | **Module System** | ESM                      | Modern, tree-shakeable, better tooling support.                                                    |
 

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
       "linux"
     ],
     "runtimes": {
-      "node": ">=18.18.0"
+      "node": ">=22.13.0"
     }
   },
   "description": "Hot-reloadable versioned prompts with easy tools for prompt engineering, chain workflows, quality gates, Symbolic syntax: >>prompt --> >>chain @framework :: 'gate'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "graphviz": "^0.0.9"
       },
       "devDependencies": {
+        "@anthropic-ai/mcpb": "2.1.2",
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
         "husky": "^9.1.7"
@@ -45,6 +46,27 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/mcpb/-/mcpb-2.1.2.tgz",
+      "integrity": "sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.1",
+        "commander": "^13.1.0",
+        "fflate": "^0.8.2",
+        "galactus": "^1.0.0",
+        "ignore": "^7.0.5",
+        "node-forge": "^1.3.2",
+        "pretty-bytes": "^5.6.0",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "mcpb": "dist/cli/cli.js"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1428,6 +1450,304 @@
         "node": ">=18"
       }
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2084,6 +2404,16 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
@@ -2106,6 +2436,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2817,6 +3154,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -2839,6 +3183,16 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2955,6 +3309,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3332,6 +3696,21 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3373,6 +3752,13 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3385,6 +3771,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/flora-colossus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/foreground-child": {
@@ -3402,6 +3802,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -3424,6 +3839,21 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/gensync": {
@@ -3602,6 +4032,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
@@ -4498,6 +4951,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4638,6 +5104,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -4667,6 +5143,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4732,6 +5218,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -4925,6 +5421,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
@@ -5029,6 +5538,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -5412,6 +5928,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5551,6 +6080,16 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -5887,6 +6426,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   ],
   "scripts": {
     "prepare": "husky || true",
+    "mcpb:validate": "mcpb validate manifest.json",
     "sync": "bash scripts/sync-to-cache.sh",
     "dev": "npm run sync && echo 'Restart Claude Code to apply hook changes'",
     "dev:claude": "bash scripts/dev-claude.sh",
     "dev:claude:resume": "bash scripts/dev-claude.sh --resume"
   },
   "devDependencies": {
+    "@anthropic-ai/mcpb": "2.1.2",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "husky": "^9.1.7"

--- a/plans/renovate-maintenance-remediation-2026-08-01-implementation-notes.md
+++ b/plans/renovate-maintenance-remediation-2026-08-01-implementation-notes.md
@@ -1,0 +1,466 @@
+# Renovate Maintenance Remediation — Implementation Notes
+
+## Status
+
+- **Lifecycle:** `migrating`
+- **Current milestone:** Phase 5 safe reconciliation complete; Phase 6 hosted rollout pending
+- **Baseline:** `main` at `2ddd763f` when Phase 1 started
+- **Phase 2 validation baseline:** `main` at `905c9261`
+- **Phase 3 validation baseline:** `main` at `b41adc43`
+- **Phase 4 validation baseline:** `main` at `d4a5360f`
+- **Concurrent work:** another session owns the existing server, test, and unrelated plan diffs
+
+## Intent
+
+Repair the dependency-policy boundary first: Renovate extraction, semantic release
+classification, grouping, labels, schedules, and Python-tool ownership should resolve
+to one reviewable policy before packaging and hosted enforcement are changed.
+
+## Phase 1 Evidence
+
+### Configuration decisions
+
+- `config:recommended` remains the base preset.
+- Targeted additions: config migration, GitHub Action digest pinning, abandonment
+  detection, preserved SemVer ranges, and weekly lock maintenance.
+- An explicit catch-all package rule restores `chore(deps)` after
+  `config:recommended` applies its dependency-specific semantic rules.
+- A later, narrower rule maps only `server/package.json` runtime dependencies to
+  `fix(deps)`.
+- Repository labels are `dependencies` plus additive `security` and
+  `vulnerability` labels for vulnerability-alert PRs.
+- Regular updates and lock maintenance use `* 0-5 * * 1` in UTC; vulnerability
+  alerts retain immediate creation and manual merge.
+- Unrelated major updates resolve without a group; TypeScript and MCP SDK retain
+  explicit manual-review groups.
+- Ruff, Pyrefly, Renovate, GitHub Actions, testing tools, and linting tools have
+  bounded ownership rules.
+- The TypeScript 7 PR notes were preserved verbatim.
+
+### Local validation
+
+| Check                                 | Result                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `renovate@44.6.0` strict validator    | pass; no configuration warnings                                          |
+| Local extract with `GITHUB_COM_TOKEN` | pass; 14 package files and 114 dependencies                              |
+| npm extraction                        | 3 manifests; root and server lock domains detected                       |
+| regex extraction                      | Ruff, Pyrefly, and Renovate each detected once                           |
+| nodenv extraction                     | `.node-version` detected once at Node 24                                 |
+| Action extraction                     | 7 external-Action package files, 61 references                           |
+| Resolved-rule samples                 | server runtime=`fix`; audited maintenance classes=`chore`; automerge off |
+| Repository label comparison           | `dependencies`, `security`, and `vulnerability` exist                    |
+
+Resolved sample groups:
+
+| Sample                 | Semantic type | Group                       |
+| ---------------------- | ------------- | --------------------------- |
+| server `express` minor | `fix`         | Server runtime dependencies |
+| root `graphviz` patch  | `chore`       | ungrouped                   |
+| TypeScript major       | `chore`       | TypeScript                  |
+| unrelated dev major    | `chore`       | ungrouped                   |
+| MCP SDK minor          | `fix`         | MCP SDK                     |
+| Ruff patch             | `chore`       | Python validation tools     |
+| Action digest          | `chore`       | GitHub Actions              |
+
+Server validation ran in an isolated clone at committed `094baec6` with the two
+Phase 1 `.github` files overlaid. This avoided reading the concurrent session's
+uncommitted source as Tier 1 evidence.
+
+| Server/repository check                | Result                                                             |
+| -------------------------------------- | ------------------------------------------------------------------ |
+| CI workflow YAML parse                 | pass                                                               |
+| scoped `git diff --check` and Prettier | pass                                                               |
+| `npm run typecheck`                    | pass                                                               |
+| `npm run lint:ratchet`                 | pass; 3,459 errors and 1,407 warnings, no regression               |
+| `npm test`                             | pass; 146 suites and 1,743 tests                                   |
+| `npm run test:ci`                      | pass; 146 suites and 1,743 tests                                   |
+| `npm run validate:all`                 | pass; existing `ulid` extension-classification warning recorded    |
+| `npm run lint`                         | fails on existing repository debt: 3,478 errors and 1,407 warnings |
+
+The full-lint failure is reported separately as required by the repository workflow;
+Tier 1 changed no linted server source, and the ratchet plus targeted gates passed.
+
+## Phase 2 Evidence
+
+### Canonical ownership and enforcement
+
+- Root `package.json` now owns exact `@anthropic-ai/mcpb@2.1.2`; the root lock
+  added 45 MCPB/transitive entries, removed none, and changed no existing entry.
+- The server MCPB validation script delegates to the root executable. The old
+  unpinned `npx` path is removed.
+- Renovate's workflow installs exact `renovate@44.6.0`, runs strict validation,
+  captures local extraction JSONL, and sends it through a fail-closed validator.
+- Workflow path filters cover the config, manifests, both lock domains,
+  `.node-version`, all Action/workflow files, `server/.npmrc`, and the validator.
+- The extraction validator rejects missing/non-JSON output, warning/error records,
+  manager/file inventory drift, policy drift, and duplicate or misplaced MCPB
+  ownership. Its utility remains below the 200-line project threshold.
+- Extension packaging now installs the server's committed production lock in an
+  isolated temporary root, copies that closure into staging, validates it, and uses
+  the exact root MCPB binary through one workflow entrypoint.
+- `chokidar` and `ulid` are explicit bundled exclusions. The validator proves both
+  bundle markers exist, both top-level packages are absent from staging, every
+  retained direct dependency exists in the lock and staged tree, and the staged
+  manifest agrees with the server manifest.
+
+### Local validation
+
+Validation used an isolated clone at committed `905c9261` with only the Renovate
+Phase 1/2 files overlaid. This prevents the parallel session's uncommitted server
+work from becoming evidence for this tier.
+
+| Check                                       | Result                                                                  |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| Root `npm ci`                               | pass; 413 packages                                                      |
+| Server `npm ci`                             | pass; 837 packages                                                      |
+| `renovate@44.6.0` strict validation         | pass; no config warning                                                 |
+| Real local extraction validator             | pass; 14 files / 115 dependencies                                       |
+| Extracted managers                          | Actions 7/61; nodenv 1/1; npm 3/50; regex 3/3                           |
+| MCPB extraction                             | exactly once from root npm manifest at `2.1.2`                          |
+| Both validator self-tests                   | pass; healthy and wrong lock/stage/exclusion/JSONL/policy cases covered |
+| MCPB manifest validation                    | pass                                                                    |
+| Two clean MCPB builds                       | pass; 16,319-file inventories and locked dependency trees equal         |
+| Staged dependency contract                  | 13 retained direct dependencies; `chokidar`/`ulid` absent               |
+| Server typecheck                            | pass                                                                    |
+| Server lint ratchet                         | pass; 3,454 errors / 1,407 warnings, no regression                      |
+| Server unit tests                           | pass; 146 suites / 1,743 tests                                          |
+| Server `validate:all`                       | pass                                                                    |
+| Changed-script ESLint + changed-file format | pass                                                                    |
+| Workflow YAML + build-script syntax         | pass                                                                    |
+| Full server ESLint                          | existing debt: 3,473 errors / 1,407 warnings; changed scripts clean     |
+
+The two archives intentionally do not have equal byte hashes: the existing esbuild
+configuration embeds `BUILD_TIME`, and ZIP metadata is time-derived. The approved
+reproducibility contract is equivalent locked dependency and file inventories; both
+comparisons passed, including the staged `.package-lock.json`.
+
+## Deviations
+
+1. **Phase 0 clean-tree guard is not yet satisfied.** The user directed Tier 1 work
+   on `main` while another session finishes. Phase 1 changes are limited to
+   `.github/renovate.json5`, `.github/workflows/ci.yml`, and these notes; the
+   concurrent session's files were not edited.
+2. **The plan's five-file Action inventory is stale.** Measured extraction reports
+   seven external-Action package files. In addition to the five listed in the plan,
+   `.github/workflows/downstream-sync.yml` and `.github/workflows/npm-publish.yml`
+   contain external mutable refs. Phase 3 must include both files before its pinning
+   gate may pass.
+3. **Local Renovate needs `GITHUB_COM_TOKEN` for warning-free Action extraction.**
+   Phase 2's validator workflow should supply the standard GitHub token without
+   logging it.
+4. **Node 24.11.1 cannot load the `re2@1.26.1` engine-supported range without an
+   engine warning.** Local strict validation used an isolated installation where
+   RE2 loaded successfully; hosted validation should run on the repository's current
+   Node 24 line and record the exact patch version.
+5. **A locked-tree MCPB spike exposed npm binary links as part of the artifact
+   contract.** Removing the intentionally bundled `ulid` package left
+   `node_modules/.bin/ulid` dangling, and MCPB correctly rejected the archive.
+   Phase 2 now removes dangling package binary links after applying exclusions and
+   validates the resulting staged tree before packing.
+6. **`server/package-lock.json` remained unchanged.** Phase 2 changes only server
+   scripts; npm lock v3 does not persist the `scripts` object. Rewriting the lock
+   would create unrelated churn, so validation proved the existing root dependency
+   metadata and every required lock entry instead.
+7. **The concurrent worktree is not a valid lint baseline.** Its in-progress server
+   edits currently add one `import-x/order` error. The isolated `905c9261` overlay
+   passes the committed lint ratchet; no concurrent source file was edited here.
+8. **The sandbox's default npm cache is read-only.** The first root install failed
+   with `EROFS`; all recorded clean-install evidence uses the same npm command with
+   `npm_config_cache` pointed at `/tmp`. The isolated clone's Husky prepare step also
+   completed normally because its Git metadata is writable.
+9. **Full ESLint remains a nonblocking debt report under the repository's explicit
+   ratchet policy.** The isolated Phase 2 overlay reports 3,473 errors and 1,407
+   warnings across the repository. Both changed validators pass targeted ESLint, and
+   the blocking source ratchet passes without regression.
+10. **The planned `>=22.0.0` server floor was not executable as written.** The server
+    imports `node:sqlite` without a launch flag. Node added that module in 22.5.0 and
+    removed the `--experimental-sqlite` requirement in 22.13.0, so Phase 4 corrected
+    the server manifest, lock root, MCPB manifest, CI minimum, and documentation to
+    `>=22.13.0`. See the [Node.js SQLite history](https://nodejs.org/download/release/latest-v22.x/docs/api/sqlite.html).
+11. **`.nvmrc` is not a canonical pin.** It was intentionally removed earlier because
+    no machine consumer read it; `.node-version` is the sole Node 24 development and
+    publish pin. Phase 4 corrected the stale completed TODO instead of recreating a
+    second path.
+12. **The first CLI validation invocation ran tests before producing `cli/dist/cpm.js`.**
+    The integration suite correctly failed on the missing artifact. Re-running the
+    CI order (typecheck → build → tests) passed, including build, tests, and help smoke
+    under the declared Node 18.18.0 floor.
+13. **The session-local `AGENTS.md` remains outside the release surface.** Git excludes
+    it through `.git/info/exclude`, and its supplied Node 18–24/`.nvmrc` guidance is
+    stale. The tracked operator handbook and contributor/runtime docs are canonical;
+    the local agent-rule source should be regenerated separately rather than added to
+    this Release Please change set.
+
+## Legacy Removal Checkpoint
+
+| Superseded artifact          | Phase 1 state | Evidence                                           |
+| ---------------------------- | ------------- | -------------------------------------------------- |
+| Global `chore(deps)` prefix  | `removed`     | resolved server/runtime and tooling samples        |
+| Generic security patch group | `removed`     | vulnerability-alert object is immediate and manual |
+| Nonexistent category labels  | `removed`     | config references only three live labels           |
+| Monthly lock schedule        | `removed`     | resolved Monday six-hour schedule                  |
+| Broad Python regex           | `removed`     | Ruff and Pyrefly each extract once                 |
+| Broad global npm regex       | `removed`     | only the Renovate workflow line is matched         |
+| MCPB workflow regex          | `removed`     | root npm manifest is the sole extraction path      |
+| Unpinned MCPB `npx`          | `removed`     | server delegates to exact root MCPB                |
+| Staged `npm install`         | `removed`     | temporary server lock + `npm ci --omit=dev`        |
+| Advisory-only unknown deps   | `removed`     | classification and staged closure now fail closed  |
+
+The configuration remains `migrating` until immutable Actions, runtime alignment,
+live GitHub reconciliation, hosted Renovate evidence, and the bounded automerge
+observation period are complete.
+
+## Growth Capture
+
+The audit plus Tier 1 implementation confirmed the compound pattern: dependency
+automation is a delivery contract, not an isolated bot configuration. Future reviews
+should trace extraction → effective rule merge → semantic release input → protected
+checks → published artifact, and should measure every dependency source rather than
+rely on a previously counted file inventory.
+
+Phase 2 added a second compound learning: reproducible packaging begins with a
+committed resolution graph, but exclusions also have consequences in generated
+binary links, staged manifests, and archive traversal. A dependency exclusion is not
+complete until the bundle, lock, staged tree, and packer all agree.
+
+Phase 4 added a third: a runtime floor should be derived from the first release where
+every directly used platform API works under the actual launch flags, not from the
+major release label. Packaging metadata, executable engines, CI minima, and public
+support tables are consumers of that single measured boundary; the self-contained
+CLI remains a separate compatibility surface.
+
+## Phase 3 Evidence
+
+### Immutable Action boundary
+
+GitHub documents a full-length commit SHA as the immutable Action reference. Each
+existing major tag was resolved through the upstream repository's Git data, and the
+exact release tag in the same-line comment was independently resolved to the same
+commit:
+
+| Action release                            | Verified upstream commit                   |
+| ----------------------------------------- | ------------------------------------------ |
+| `actions/checkout@v7.0.1`                 | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
+| `actions/setup-node@v7.0.0`               | `820762786026740c76f36085b0efc47a31fe5020` |
+| `actions/upload-artifact@v7.0.1`          | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
+| `actions/download-artifact@v8.0.1`        | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
+| `actions/github-script@v9.0.0`            | `3a2844b7e9c422d3c10d287c895573f7108da1b3` |
+| `googleapis/release-please-action@v5.0.0` | `45996ed1f6d02564a971a2fa1b5860e934307cf7` |
+| `peter-evans/create-pull-request@v8.1.1`  | `5f6978faf089d4d20b00c7766989d076bb2fc7f1` |
+| `softprops/action-gh-release@v3.0.2`      | `3d0d9888cb7fd7b750713d6e236d1fcb99157228` |
+
+- All 41 external references across the composite action and six workflows now use
+  those 40-character lowercase commits with exact release comments.
+- `validate-github-action-pins.js` is a stateless, 96-line filesystem policy
+  validator. It rejects mutable refs, uppercase or short SHAs, absent/unreadable
+  release comments, and malformed `uses:` lines while allowing repository-local
+  actions.
+- The validator and its self-test are part of `validate:all`. Mutable and malformed
+  negative fixtures are required to fail.
+- Renovate extraction still finds seven external-Action package files and reports all
+  41 Action dependencies with `currentDigest` set to a full SHA. The digest helper
+  remains responsible for maintainable future updates.
+
+### Local validation
+
+Validation used an isolated clone at committed `b41adc43` with only the Renovate
+Phase 1–3 files overlaid.
+
+| Check                             | Result                                                             |
+| --------------------------------- | ------------------------------------------------------------------ |
+| Upstream release-tag dereference  | pass; 8/8 comments resolve to their pinned commits                 |
+| Action pin repository scan        | pass; 41 refs / 10 YAML files                                      |
+| Action pin validator self-test    | pass; healthy, mutable, uppercase, commentless, malformed cases    |
+| Mutable external `@vN` search     | pass; zero matches                                                 |
+| YAML parse                        | pass; composite action plus six workflows                          |
+| Renovate strict + real extraction | pass; all 41 Action dependencies digest-pinned                     |
+| Changed-file ESLint + Prettier    | pass                                                               |
+| Server typecheck                  | pass                                                               |
+| Server lint ratchet               | pass; 3,454 errors / 1,407 warnings, no regression                 |
+| Server unit tests                 | pass; 145 suites / 1,754 tests                                     |
+| Server `validate:all`             | pass                                                               |
+| Full server ESLint                | existing debt: 3,473 errors / 1,407 warnings; changed script clean |
+
+Hosted workflow execution is not yet evidence because `autonomous_commit:false` and
+the user is accumulating tiers on `main`. The seven YAML files must pass on the
+eventual PR before Phase 5 may enable repository full-SHA enforcement.
+
+### Phase 3 Removal Checkpoint
+
+| Superseded artifact                 | State       | Evidence                                   |
+| ----------------------------------- | ----------- | ------------------------------------------ |
+| External mutable major Action refs  | `removed`   | zero external `uses:` refs with `@vN`      |
+| Manual-only Action pin review       | `removed`   | repository scan and negative self-test     |
+| Unverified pin provenance           | `removed`   | eight upstream release tags dereferenced   |
+| Repository full-SHA policy disabled | `migrating` | enable only after hosted workflow evidence |
+
+The code path for Action pinning is locally canonical. Live enforcement remains
+`migrating` until the eventual PR passes and Phase 5 applies the repository policy.
+
+## Phase 4 Evidence
+
+### Runtime boundary
+
+- Server executable, lock-root, and packaged metadata now agree on Node.js
+  `>=22.13.0`; CI proves that exact minimum plus the Node 24 shipping line.
+- The standalone CPM CLI remains a distinct Node.js `>=18.18.0` surface.
+- `.node-version` remains the sole Node 24 local-development and publish pin.
+- The tracked operator handbook, contributor guide, server README, deployment
+  prerequisite, design decision, completed TODO, and current changelog entry now
+  project those same boundaries.
+- A tracked-file stale-claim scan found no remaining Node 18 server claim, broad
+  Node 22 minimum, Node 18→24 server matrix, or `.nvmrc` policy reference. The
+  `.gitattributes` entry for the possible filename is metadata, not a support claim.
+
+### Local validation
+
+Validation used an isolated clone at committed `d4a5360f` with only the Renovate
+Phase 1–4 files overlaid, so the other session's uncommitted server work did not
+become Phase 4 evidence.
+
+| Check                                          | Result                                                                               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Root and server clean installs                 | pass; committed root/server resolution graphs                                        |
+| MCPB manifest schema                           | pass                                                                                 |
+| Server build and extension dependency contract | pass                                                                                 |
+| Server typecheck                               | pass                                                                                 |
+| Server lint ratchet                            | pass; 3,454 errors / 1,407 warnings, no regression                                   |
+| Server unit tests                              | pass; 145 suites / 1,754 tests                                                       |
+| Server `validate:all`                          | pass, including format, architecture, contracts, manifests, and validator self-tests |
+| Node 22.13.0 server startup                    | pass; all startup phases completed                                                   |
+| Node 24 CLI typecheck, build, and tests        | pass; 3 suites / 75 tests                                                            |
+| Node 18.18.0 CLI build, tests, and help smoke  | pass; 3 suites / 75 tests                                                            |
+| Full server ESLint                             | existing debt: 3,473 errors / 1,407 warnings; ratchet remains the blocking policy    |
+
+Hosted matrix runs remain pending because the accumulated tiers are intentionally
+uncommitted. The eventual PR must pass both `Test (Node 22.13.0)` and `Test (Node 24)`
+before this support boundary is release evidence.
+
+### Phase 4 Removal Checkpoint
+
+| Superseded artifact                        | State     | Evidence                                               |
+| ------------------------------------------ | --------- | ------------------------------------------------------ |
+| Node 18 packaged-server claim              | `removed` | manifest and public server docs use >=22.13.0          |
+| Imprecise >=22.0.0 executable floor        | `removed` | server manifest/lock and exact-minimum startup agree   |
+| Node 18→24 server CI claim                 | `removed` | exact server matrix is 22.13.0 plus 24                 |
+| `.nvmrc` dual-pin guidance                 | `removed` | tracked policy names `.node-version` only              |
+| Collapsed server/CLI compatibility surface | `removed` | support tables and exact-line validation split the two |
+
+The runtime-support path is locally canonical. Hosted workflow proof remains a PR
+exit criterion rather than a parallel implementation.
+
+## Phase 5 Evidence
+
+### Ingestion and pre-flight
+
+- **Tier:** five items were initially combined. The three safe reconciliation items
+  remain Phase 5; the two commit-dependent hosted mutations moved to Phase 6 so no
+  external wait is hidden inside this tier's gate.
+- **Execution order:** 5.1 required-context foundation → 5.2 branch protection;
+  5.3 labels/security was an independent audit. Full-SHA activation and Renovate App
+  evidence now execute after an isolated implementation PR in Phase 6.
+- **Work type:** configuration/external integration; secondary type security policy;
+  risk high because an incorrect required context or premature SHA policy could block
+  every workflow or merge.
+- **Files:** one existing JSON SSOT plus plan/evidence updates. No new source, test,
+  external library, API surface, visual design, or persistent application state.
+
+### Repository SSOT and live settings
+
+- `.github/required-contexts.json` now pipes `{strict:true, contexts:[...]}` JSON to
+  the branch-protection endpoint instead of piping four plain-text lines to an API
+  that expects an object.
+- The required-context validator and its falsifiable self-test pass; all four names
+  resolve to current workflow job names, and tracked root formatting passes.
+- Before reconciliation, live protection was strict but required only `Lint &
+Validate` and `Build`. Current `main` had recent successful check runs for those
+  names plus `CLI` and `Test Suite`.
+- The planned PATCH was applied. A read-back now returns `strict:true` and exactly
+  `Lint & Validate`, `Build`, `CLI`, and `Test Suite`, each bound to the GitHub Actions
+  app.
+- Labels `dependencies`, `security`, and `vulnerability` already exist; no label was
+  created.
+- Vulnerability alerts are enabled (HTTP 204 probe). Automated security fixes report
+  `{enabled:false, paused:false}`, matching the policy that Renovate owns regular
+  dependency PRs while alerts remain available.
+
+### Guarded stop before Actions and Renovate mutation
+
+- Repository Actions currently report `{enabled:true, allowed_actions:"all",
+sha_pinning_required:false}`.
+- Remote `main` still contains mutable refs such as `actions/checkout@v7`,
+  `actions/setup-node@v7`, and artifact Actions by major tag. The locally pinned
+  workflows have not been committed or exercised by GitHub.
+- Enabling `sha_pinning_required` now would reject current remote workflows before
+  their pinned replacements have hosted evidence. Phase 6.3 therefore remains
+  `migrating`; the live policy was intentionally left unchanged.
+- No Renovate PR is currently open. Dashboard issue #157 reflects the pre-remediation
+  configuration (including a production group titled `chore(deps)`), so it cannot
+  prove the new semantic types, groups, extraction contract, or required checks.
+  Triggering Renovate before the configuration is committed would test the wrong
+  policy; Phase 6.5 remains pending.
+
+### Phase 5 checkpoint
+
+| Item                         | State       | Evidence / next guard                                  |
+| ---------------------------- | ----------- | ------------------------------------------------------ |
+| 5.1 required-context SSOT    | `canonical` | validator, self-test, and JSON shape pass              |
+| 5.2 branch protection        | `canonical` | strict read-back contains exactly four contexts        |
+| 5.3 labels/security          | `canonical` | three labels present; alerts on; security fixes off    |
+| 6.3 full-SHA Actions policy  | `migrating` | isolated PR → hosted workflows pass → enable → rerun   |
+| 6.5 hosted Renovate evidence | `migrating` | merge config → trigger app → inspect representative PR |
+
+The re-scoped Phase 5 gate is satisfied: tracked and live safe settings agree without
+enabling a policy current remote workflows cannot meet. Phase 6 owns the isolated
+commit/PR, hosted evidence, policy activation, landing audit, and Renovate run. Local
+tier-wide suites are not reclassified as hosted evidence because they cannot satisfy
+those guards.
+
+## Phase 6 Evidence
+
+### Isolation and landing guard
+
+- The shared `main` worktree had extensive concurrent source/test renames and edits,
+  plus 16 committed changes not yet present on GitHub. Phase 6 did not switch its
+  branch, stage its index, stash, reset, clean, or copy any unrelated dirty file.
+- A no-hardlink clone at `/tmp/renovate-rollout-Hj45Vn/repo` was created from local
+  commit `467ee5a45bb0d4293907f8267258bae1900b26b4` on branch
+  `fix/renovate-delivery-contract`. Only the 28 enumerated Phase 1–6 files were
+  overlaid.
+- GitHub `main` remains at `0b17526640614d14328dc76b61023fa63b3358f5` and does not
+  contain the isolated branch base; the local base is 16 commits ahead. The branch
+  must not be pushed or opened as a PR until
+  `git merge-base --is-ancestor 467ee5a4 github/main` succeeds. Otherwise the PR
+  would falsely include the other session's commits.
+
+### Pre-PR local validation
+
+| Check                                                                        | Result                                                                        |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Root and server clean installs                                               | pass; committed lock domains                                                  |
+| Server typecheck                                                             | pass                                                                          |
+| Server lint ratchet                                                          | pass; 3,437 errors / 1,405 warnings, no regression                            |
+| Test typecheck ratchet                                                       | pass; 395 recorded test errors, no regression                                 |
+| Server unit tests                                                            | pass; 145 suites / 1,754 tests                                                |
+| Server `validate:all`                                                        | pass                                                                          |
+| Required-context and Action-pin validators/self-tests                        | pass; four contexts and 41 pinned refs                                        |
+| Renovate 44.6.0 strict validation                                            | pass under Node 24.15.0                                                       |
+| Real Renovate extraction/policy contract                                     | pass                                                                          |
+| MCPB schema, locked build, staged dependency contract, and packed validation | pass; 16,319 files                                                            |
+| Full server ESLint                                                           | existing debt: 3,456 errors / 1,405 warnings; ratchet remains blocking policy |
+
+The local Node 24.11.1 pin cannot install Renovate's optional `re2@1.26.1`, whose
+published engine range now starts at Node 24.15.0 on the Node 24 line. A first strict
+validation attempt therefore failed closed on Renovate's RE2 fallback warning. The
+recorded strict/extraction evidence used Node 24.15.0, where RE2 installed and loaded;
+the hosted workflow's floating Node 24 pin must report its exact patch version.
+
+### Phase 6 checkpoint
+
+| Item                           | State       | Guard                                                                         |
+| ------------------------------ | ----------- | ----------------------------------------------------------------------------- |
+| 6.1 isolated implementation PR | `migrating` | local scoped commit created; wait for remote base synchronization before push |
+| 6.2 hosted pre-policy evidence | `pending`   | requires safe PR                                                              |
+| 6.3 full-SHA Actions policy    | `pending`   | requires 6.2 pass                                                             |
+| 6.4 protected PR landing       | `pending`   | requires policy reruns pass                                                   |
+| 6.5 hosted Renovate evidence   | `pending`   | requires merged policy                                                        |

--- a/plans/renovate-maintenance-remediation-2026-08-01.md
+++ b/plans/renovate-maintenance-remediation-2026-08-01.md
@@ -1,0 +1,344 @@
+# Renovate and Dependency-Maintenance Remediation Plan
+
+**Status:** in progress  
+**Lifecycle:** current configuration = `migrating`; remediated configuration = `canonical` only after Phase 7  
+**Baseline verified:** local `main` at `2ddd763f` on 2026-08-01  
+**Owner:** repository maintainer  
+**Risk:** high — merge protection, release triggering, dependency supply chain, and published artifacts
+
+## 1. Intent Declaration
+
+- **Work type:** `refactor`
+- **Secondary type:** `bug_fix`
+- **Confidence:** high
+- **Problem:** dependency updates are discovered, classified, protected, released, and packaged by separate policies that currently disagree. A schema-valid Renovate PR may use a non-releasable commit type, bypass two intended checks, execute mutable Actions, miss pinned tools, or package dependencies resolved outside a committed lock.
+- **Desired state:** one enforced path from dependency extraction through release and artifact validation, with narrowly bounded automation and documented runtime support.
+- **Next phase before source edits:** `/refactoring` pre-flight.
+- **External versions at plan time:** `renovate@44.6.0`, `@anthropic-ai/mcpb@2.1.2`.
+
+### Acceptance criteria
+
+1. Server production dependencies resolve to `fix(deps)`; development, Action, Python-tool, and root-tooling updates resolve to `chore(deps)`.
+2. Extraction finds all three npm manifests, both lock domains, seven external-Action files, `.node-version`, Ruff, Pyrefly, Renovate, and MCPB.
+3. Every external Action reference is a verified 40-character commit SHA with a readable same-line version comment.
+4. `main` requires exactly `Lint & Validate`, `CLI`, `Build`, and `Test Suite`.
+5. Extension dependency versions come from a committed lock and two clean builds produce equivalent unpacked dependency/file inventories.
+6. Server runtime metadata states Node >=22.13.0; CLI remains >=18.18; local and publish tooling use Node 24; server CI covers 22.13.0 and 24.
+7. The obsolete security rule, nonexistent labels, broad MCPB regex path, unpinned MCPB invocation, unlocked staging install, monthly lock schedule, and conflicting range strategy are removed.
+8. Limited automerge is enabled only after two successful scheduled cycles and excludes 0.x, production, major, Action, TypeScript, MCP SDK, vulnerability, and critical-tool updates.
+
+## 2. Context and Evidence
+
+### Compound diagnosis: policy-to-delivery contract drift
+
+```text
+manifest/tool version
+  -> Renovate extraction and rule merge
+  -> PR semantic type, labels, group, and checks
+  -> main branch protection
+  -> Release Please
+  -> npm and MCPB artifacts
+```
+
+The individual mechanisms exist, but the contract between them is incomplete:
+
+| Severity | Evidence                                                                                               | Consequence                                                                              |
+| -------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Critical | `.github/renovate.json5:35` applies `chore(deps)` globally; `release-please-config.json` hides `chore` | Bundled production dependency updates may merge without creating a server patch release. |
+| High     | `.github/required-contexts.json:17` declares four checks; live protection was observed with only two   | A dependency PR can merge without CLI or test-matrix evidence.                           |
+| High     | Seven workflow/composite files use mutable major Action tags                                           | A moved tag can change executable CI code without a repository diff.                     |
+| High     | `.github/workflows/ci.yml:69` installs Ruff and Pyrefly on one line; extraction observed only Ruff     | Pyrefly can age without an update PR.                                                    |
+| High     | `scripts/build-extension.sh:77,83` uses unlocked `npm install` and unpinned `npx`                      | Rebuilding the same source may resolve a different dependency/tool graph.                |
+| Medium   | Rule-level `labels` references many labels absent from the repository                                  | Labels may replace each other because Renovate documents `labels` as non-mergeable.      |
+| Medium   | Broad major groups and stale lint package names overlap specific rules                                 | Unrelated breaking changes can share a PR; intended review rules may be obscured.        |
+| Medium   | Duplicate presets and `rangeStrategy:auto` conflict with `:preserveSemverRanges`                       | Effective policy is harder to predict and review.                                        |
+| Medium   | Three-hour weekly schedule and monthly lock maintenance                                                | Hosted execution timing can delay updates and lock convergence.                          |
+| Medium   | `manifest.json`, `CONTRIBUTING.md`, `server/README.md`, and historical docs claim Node 18 support      | Operators can select a runtime below the server's `node:sqlite` floor.                   |
+
+### Verified implementation surface
+
+| Path                                                                         |                                           Verified symbol/line | Planned disposition                                        |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------: | ---------------------------------------------------------- |
+| `.github/renovate.json5`                                                     | 247 lines; rules 45; alerts 180; locks 202; regex managers 227 | Edit; preserve TypeScript 7 notes.                         |
+| `.github/required-contexts.json`                                             |                                                    contexts 17 | Retain four names; correct apply example.                  |
+| `server/scripts/validate-required-contexts.js`                               |                                            `findViolations` 72 | Reuse unchanged unless validation integration requires it. |
+| `.github/workflows/ci.yml`                                                   |                                  stable names 41, 97, 134, 247 | Split Python installs; pin Actions.                        |
+| `.github/workflows/downstream-sync.yml`, `.github/workflows/npm-publish.yml` |                                           external Action refs | Pin Actions; include both in the Action-policy gate.       |
+| `release-please-config.json`                                                 |                             release type 3; changelog types 11 | Reuse as release contract.                                 |
+| `scripts/build-extension.sh`                                                 |                                            install 77; MCPB 83 | Replace both nondeterministic paths.                       |
+| `server/scripts/validate-extension-deps.js`                                  |                                   required/excluded sets 24/42 | Extend existing validator.                                 |
+| `.github/workflows/renovate-config-validator.yml`                            |                                           strict validation 34 | Add extraction validation.                                 |
+| `package.json` / `package-lock.json`                                         |                                   dev dependencies 17; lock v3 | Own exact MCPB version.                                    |
+| `server/package.json` / `server/package-lock.json`                           |                                   MCPB validation 125; lock v3 | Delegate to root tool; sync lock metadata.                 |
+| `manifest.json`                                                              |                                            Node requirement 13 | Raise server runtime floor to 22.                          |
+| `project-decisions.md`                                                       |                                        Node 22 rationale 19–29 | Reuse, do not duplicate.                                   |
+| `AGENTS.md`                                                                  |                                   absent from tracked baseline | Do not edit or reference as a repository path.             |
+
+## 3. Design Decisions
+
+1. **Use a targeted preset set, not wholesale `config:best-practices`.** Keep `config:recommended` and add config migration, Action digest pinning, abandonment detection, preserved ranges, and weekly lock behavior explicitly. This avoids inheriting exact dev-dependency pinning and a second npm release-age policy.
+2. **Treat semantic commit type as a release interface.** Default to `chore(deps)` and override server production dependencies to `fix(deps)`.
+3. **Use a minimal real label vocabulary.** Top-level `dependencies`; additive `security` and `vulnerability` only. Review requirements belong in reviewer/rule behavior, not a large label taxonomy.
+4. **Keep vulnerability changes immediate and manual.** Dependabot alerts remain enabled as a data source; Dependabot security PR creation remains disabled so Renovate is the sole remediation path.
+5. **Isolate breaking changes.** Do not group unrelated majors. Give TypeScript, MCP SDK, testing, linting, Actions, and Python tools explicit boundaries.
+6. **Pin Actions twice:** full SHA in source and an automated validator; Renovate's digest helper maintains the pins.
+7. **Reuse the server lock for extension staging.** Copy the server manifest, lock, and `.npmrc` to a temporary install root, run `npm ci --omit=dev --ignore-scripts`, and then produce the filtered staged manifest. Do not create a second committed dependency manifest/lock.
+8. **Make local extraction blocking while Renovate is pinned.** The local platform is documented as experimental, so a Renovate bump must update the parser and evidence atomically if output shape changes.
+9. **Do not add npm `min-release-age` now.** Renovate remains the age gate. Reconsider only when every supported CI line uses a verified compatible npm and an emergency-exclusion procedure exists.
+10. **Automerge follows observation.** First deploy with automerge disabled; enable only stable nonmajor development and lock refreshes after two successful weekly cycles.
+
+### Primary references
+
+- Renovate best-practice preset contents: <https://docs.renovatebot.com/presets-config/>
+- Renovate local extraction and limitations: <https://docs.renovatebot.com/modules/platform/local/>
+- Mergeable `addLabels`: <https://docs.renovatebot.com/configuration-options/#addlabels>
+- GitHub Action digest management: <https://docs.renovatebot.com/modules/manager/github-actions/>
+- GitHub immutable Action guidance: <https://docs.github.com/en/actions/reference/security/secure-use>
+- GitHub protected-branch API: <https://docs.github.com/en/rest/branches/branch-protection>
+- Release Please conventional-commit behavior: <https://github.com/googleapis/release-please>
+- npm release-age configuration: <https://docs.npmjs.com/cli/using-npm/config/#min-release-age>
+
+## 4. Implementation Plan
+
+### Phase 0 — Establish a reversible baseline
+
+| #   | Target          | Change                                                                                                                 | Depends | Verification                                                            |
+| --- | --------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------- |
+| 0.1 | Git worktree    | Wait for the parallel session to finish; require clean `main`; record the new HEAD. Do not reset or stash its changes. | none    | `git branch --show-current && git status --short && git rev-parse HEAD` |
+| 0.2 | GitHub settings | Capture labels, Dependabot settings, Actions policy, and branch protection JSON.                                       | 0.1     | `gh label list`; branch-protection and settings API output              |
+| 0.3 | Upstream tools  | Reconfirm MCPB/Renovate versions and dereference each Action release tag to an upstream commit.                        | 0.1     | npm registry output and GitHub tag-object evidence                      |
+
+**Gate:** clean-tree evidence, before-state GitHub JSON, and upstream provenance are recorded in implementation notes.
+
+### Phase 1 — Repair Renovate policy
+
+**Status:** complete locally on 2026-08-02; hosted evidence remains in Phase 6.
+
+| #   | File                       | Change                                                                                                                                                   | Depends | Verification                                      |
+| --- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------- |
+| 1.1 | `.github/renovate.json5`   | Remove duplicate presets; add targeted migration, digest, abandonment, preserved-range, and weekly-lock behavior. Delete top-level `rangeStrategy:auto`. | Phase 0 | Strict validator and resolved-config review       |
+| 1.2 | same                       | Delete global prefix; explicitly default to `chore(deps)` and override server production dependencies to `fix(deps)`.                                    | 1.1     | Extraction assertions for representative packages |
+| 1.3 | same                       | Replace rule-level labels with top-level `dependencies` and additive security labels; delete references to nonexistent labels.                           | 1.1     | Compare configuration labels with `gh label list` |
+| 1.4 | same                       | Delete the contradictory generic security/auto-merge rule; retain immediate manual vulnerability alerts and the 3-day strict regular-update age.         | 1.1     | Resolved alert policy                             |
+| 1.5 | same                       | Rebuild bounded groups; isolate majors, TypeScript, and MCP SDK; update lint package names; preserve the TypeScript 7 notes verbatim.                    | 1.1     | Resolved groups from real extraction              |
+| 1.6 | same                       | Use a six-hour Monday window, weekly lock maintenance, existing PR rate limits, and matching dashboard text. Keep automerge off.                         | 1.1     | Resolved schedules and dashboard output           |
+| 1.7 | `.github/workflows/ci.yml` | Put Ruff and Pyrefly on separate exact-version install lines.                                                                                            | Phase 0 | Both tools run in `Lint & Validate`               |
+| 1.8 | `.github/renovate.json5`   | Narrow the PyPI regex to the two exact line shapes. Preserve only narrowly scoped Renovate workflow matching until its ownership changes.                | 1.7     | Ruff and Pyrefly extracted exactly once           |
+
+**Gate:** exact Renovate strict validation plus local extraction; no warning, missing manager, duplicate dependency, nonexistent label, or unexpected semantic type/group.
+
+### Phase 2 — Enforce extraction and deterministic MCPB packaging
+
+**Status:** complete locally on 2026-08-02; publication-workflow and hosted
+Renovate evidence remain in Phase 6.
+
+| #   | File                                                     | Change                                                                                                                                                                                                      | Depends       | Verification                                      |
+| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ------------------------------------------------- |
+| 2.1 | `server/scripts/validate-renovate-extraction.js` **new** | Parse pinned Renovate JSONL; assert manifest/lock managers, Action files, nodenv, Ruff, Pyrefly, Renovate, MCPB, representative groups, and semantic types. Include `--self-test`; reject empty extraction. | Phase 1       | Self-test plus real output                        |
+| 2.2 | `.github/workflows/renovate-config-validator.yml`        | Trigger on every extraction source; install exact Renovate; run strict schema, local extraction, and assertions.                                                                                            | 2.1           | Local command parity and PR run                   |
+| 2.3 | `package.json`, `package-lock.json`                      | Add exact MCPB as root dev dependency and root validation script; regenerate only root/workspace lock.                                                                                                      | Phase 0       | Root `npm ci`; MCPB validate; npm extraction      |
+| 2.4 | `scripts/build-extension.sh`                             | Invoke root MCPB; replace staged `npm install` with `npm ci` in a temporary copy of server manifest/lock/`.npmrc`; copy the locked production tree; emit existing filtered runtime manifest.                | 2.3           | Two clean builds and inventory comparison         |
+| 2.5 | `server/scripts/validate-extension-deps.js`              | Prove required dependencies exist in the server lock, exclusions are intentional bundles, and staged tree/manifest agree. Extend self-test.                                                                 | 2.4           | Extension validator and self-test                 |
+| 2.6 | `server/package.json`, `server/package-lock.json`        | Delegate MCPB validation to root; register new validators in `validate:all`; sync lock root metadata without unrelated upgrades.                                                                            | 2.1, 2.3, 2.5 | Server `npm ci`; narrow lock diff; `validate:all` |
+| 2.7 | `.github/workflows/extension-publish.yml`                | Ensure root `npm ci` precedes MCPB use and packaging has one entrypoint.                                                                                                                                    | 2.3–2.6       | Publication workflow and artifact validation      |
+| 2.8 | `.github/renovate.json5`                                 | Delete MCPB/global-tool regex management superseded by the root manifest. Keep one Renovate dependency path.                                                                                                | 2.2, 2.3      | Exactly one extraction for each tool              |
+
+**Gate:** root/server `npm ci`; strict/extract validation; extension dependency validation; two clean MCPB builds; server typecheck and lint ratchet.
+
+### Phase 3 — Pin and enforce GitHub Actions
+
+**Status:** complete locally on 2026-08-02; hosted workflow evidence requires the
+isolated implementation PR before repository full-SHA enforcement in Phase 6.
+
+| #   | File                                                                                      | Change                                                                                                                                                    | Depends | Verification                  |
+| --- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
+| 3.1 | `.github/actions/setup-node-install/action.yml`                                           | Pin all setup-node calls to verified full SHAs with version comments.                                                                                     | Phase 0 | Provenance plus pin validator |
+| 3.2 | `.github/workflows/ci.yml`                                                                | Pin checkout, setup-node, artifact, and github-script actions.                                                                                            | 1.7     | Four stable CI jobs pass      |
+| 3.3 | `.github/workflows/extension-publish.yml`                                                 | Pin checkout, artifacts, releases, and PR creation actions.                                                                                               | 2.7     | Extension workflow passes     |
+| 3.4 | `.github/workflows/downstream-sync.yml`, `.github/workflows/npm-publish.yml`              | Pin checkout and setup-node actions.                                                                                                                      | Phase 0 | Both workflows pass           |
+| 3.5 | `.github/workflows/release-please.yml`, `.github/workflows/renovate-config-validator.yml` | Pin Release Please, checkout, and setup-node actions.                                                                                                     | 2.2     | Both workflows pass           |
+| 3.6 | `server/scripts/validate-github-action-pins.js` **new**                                   | Reject non-local `uses:` refs unless they contain exactly 40 lowercase hexadecimal characters and a same-line version/ref comment. Include `--self-test`. | 3.1–3.5 | Self-test and repository scan |
+| 3.7 | `server/package.json`                                                                     | Add the pin validator and its self-test to `validate:all`.                                                                                                | 3.6     | Server `validate:all`         |
+
+**Gate:** pin validator passes; no external `@vN` refs remain; every affected workflow passes on a PR.
+
+### Phase 4 — Align runtime documentation
+
+**Status:** complete locally on 2026-08-02; the eventual PR must provide the
+hosted Node 22.13.0 and 24 matrix evidence.
+
+| #   | File                                                     | Change                                                                                                                                   | Depends    | Verification                         |
+| --- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------ |
+| 4.1 | `manifest.json`, server manifest and lock                | Set the packaged and executable server requirement to Node >=22.13.0, the first Node 22 release where `node:sqlite` is unflagged.        | Phase 2    | Manifest and MCPB validation         |
+| 4.2 | `CLAUDE.md`, `CONTRIBUTING.md`                           | Add one support table: server >=22.13.0; server CI 22.13.0+24; CLI >=18.18; local/publish Node 24.                                       | 4.1        | Documentation search and review      |
+| 4.3 | `server/README.md`, `docs/portfolio/design-decisions.md` | Update public server/runtime claims to >=22.13.0 and document the `node:sqlite` rationale.                                               | 4.1        | Repository-wide stale-version search |
+| 4.4 | `docs/TODO.md`                                           | Correct completed pin and CI-policy entries, then separate server, CLI, and development support.                                         | 4.2        | Repository-wide stale-version search |
+| 4.5 | Existing canonical files and CI                          | Verify `project-decisions.md`, `.node-version`, server/CLI engines, and CI; correct any support boundary the verification disproves.     | 4.2–4.4    | Targeted `rg` and matrix tests       |
+| 4.6 | `CHANGELOG.md`                                           | Add an Unreleased Changed entry for dependency automation, packaging reproducibility, immutable Actions, checks, and support boundaries. | Phases 1–4 | Changelog review                     |
+
+**Gate:** no stale Node support claim; manifest validation; server typecheck, lint ratchet, tests, and `validate:all`; CLI validation on supported CI lines.
+
+### Phase 5 — Reconcile live GitHub settings
+
+**Status:** complete on 2026-08-02. Repository policy and the safe live settings are
+canonical; hosted activation is isolated in Phase 6 so this tier has no external wait
+inside its gate.
+
+| #   | Target                           | Change                                                                                                | Depends                                                | Verification               |
+| --- | -------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | -------------------------- |
+| 5.1 | `.github/required-contexts.json` | Correct the example to send `{strict:true,contexts:[...]}` JSON; retain the four names.               | Phase 3                                                | Required-context validator |
+| 5.2 | Branch protection                | Apply the SSOT with `jq '{strict:true, contexts}' ...                                                 | gh api -X PATCH .../required_status_checks --input -`. | 5.1 and recent check runs  | GET returns exactly four contexts and strict mode |
+| 5.3 | Labels/security                  | Verify the three labels; create only a missing one. Verify alerts on and Dependabot security PRs off. | Phase 1                                                | GitHub settings evidence   |
+
+**Gate:** the tracked required-context SSOT, branch-protection read-back, labels, and
+security settings match the repository policy without enabling a policy that current
+remote workflows cannot satisfy.
+
+### Phase 6 — Hosted rollout and full-SHA activation
+
+**Status:** in progress on 2026-08-02. The isolated branch contains one validated,
+tier-scoped commit on local base `467ee5a4`; do not push or open the PR until that base
+is an ancestor of remote `main`. The shared dirty worktree remains untouched by
+branch, index, or cleanup operations.
+
+| #   | Target                     | Change                                                                                                                                                             | Depends | Verification                                   |
+| --- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------------------------------------------- |
+| 6.1 | Isolated implementation PR | Create a tier-scoped branch from a synchronized remote `main`; apply and commit only the accumulated Renovate Phase 1–5 files.                                     | Phase 5 | PR diff contains no concurrent-session work    |
+| 6.2 | Hosted pre-policy evidence | Run the PR before SHA enforcement; require all affected workflows, the four protected checks, Renovate validation, pin validation, and packaging validation.       | 6.1     | Hosted checks pass on the pinned PR head       |
+| 6.3 | Actions policy             | Preserve `enabled` and `allowed_actions`, enable `sha_pinning_required`, then rerun the same PR workflows. Roll back the boolean immediately if a workflow fails.  | 6.2     | Policy GET is true and reruns pass             |
+| 6.4 | PR landing                 | Merge only through the protected PR after confirming its merge base, changed-file inventory, approvals, and four required checks; verify `main` after the merge.   | 6.3     | Merge commit/tree contains only approved scope |
+| 6.5 | Renovate App               | Trigger a Mend-hosted run after merge and inspect its job/dashboard/representative PR for semantic type, group, labels, schedule, extraction, and required checks. | 6.4     | Representative hosted PR and job-log evidence  |
+
+**Gate:** the isolated PR lands without concurrent-session work; full-SHA policy is
+enabled and its reruns pass; the committed Renovate policy produces representative
+hosted evidence; a Renovate PR cannot merge until all four protected checks pass.
+
+### Phase 7 — Bounded automerge and migration closeout
+
+| #   | Target                   | Change                                                                                                                                          | Depends | Verification                                 |
+| --- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------------- |
+| 7.1 | Observation ledger       | Record two consecutive weekly cycles with no extraction miss, protection bypass, packaging mismatch, or incorrect release classification.       | Phase 6 | Two dated sets of PR/check/artifact evidence |
+| 7.2 | `.github/renovate.json5` | Enable platform PR automerge only for stable nonmajor dev dependencies and lock maintenance, with 14-day age and explicit high-risk exclusions. | 7.1     | Resolved config plus canary dev patch        |
+| 7.3 | `.github/renovate.json5` | Delete rollout-only `automerge:false` fields from the eligible rules once 7.2 is canonical; retain durable manual exclusions.                   | 7.2     | Config search and resolved config            |
+| 7.4 | Plan and notes           | Mark every superseded path removed and the new path canonical. Do not close with a migrating item.                                              | 7.2–7.3 | Final removal matrix and clean tree          |
+
+**Gate:** canary merges only after four checks; full validation passes; removal searches are clean; lifecycle table contains only `canonical` or `removed`.
+
+## 5. Validation Strategy
+
+### Testing strategy
+
+| What to test                         | Type                      | Location                                      | Why                                                  |
+| ------------------------------------ | ------------------------- | --------------------------------------------- | ---------------------------------------------------- |
+| Config schema and deprecations       | Contract                  | Renovate validator workflow                   | Rejects invalid or migrated options.                 |
+| Manager coverage and effective rules | Integration               | local Renovate extraction + new validator     | Proves discovery and merged policy, not only syntax. |
+| Extraction validator parser          | Unit/self-test            | `validate-renovate-extraction.js --self-test` | Locks parser behavior to the pinned Renovate output. |
+| Action pin syntax                    | Static policy + self-test | `validate-github-action-pins.js`              | Rejects mutable executable references.               |
+| Required check names                 | Contract                  | existing required-context validator           | Keeps workflow names and SSOT aligned.               |
+| Live required checks                 | External integration      | GitHub branch protection + canary PR          | Proves settings, not only files.                     |
+| Extension dependency closure         | Contract/integration      | existing extension validator + staged tree    | Proves required/excluded dependencies agree.         |
+| Extension reproducibility            | Artifact comparison       | two clean MCPB builds                         | Detects unlocked resolution or staging drift.        |
+| Release semantics                    | Hosted integration        | representative Renovate PR + Release Please   | Proves `fix(deps)` reaches release machinery.        |
+| Node support                         | Matrix/system             | server 22/24; CLI supported floor             | Proves the documented deliverable boundaries.        |
+
+### Commands
+
+Run from `server/` unless a command explicitly changes directory:
+
+```bash
+npm run typecheck
+npm run typecheck:tests
+npm run lint:ratchet
+npm run test:ci
+npm run validate:all
+npm run validate:arch
+npm run pack:mcpb
+npm run pack:mcpb:validate
+```
+
+Run from repository root:
+
+```bash
+npm ci
+npm run mcpb:validate
+renovate-config-validator --strict .github/renovate.json5
+renovate --platform=local --dry-run=extract
+node server/scripts/validate-renovate-extraction.js < extraction.jsonl
+node server/scripts/validate-github-action-pins.js
+```
+
+The full `npm run lint` and `npm run validate:all` status must be reported separately if existing debt causes a failure; targeted gates remain blocking for changed behavior.
+
+## 6. Completion Contract
+
+### Done criteria
+
+| Criterion                | Validation                       | Pass condition                                                   |
+| ------------------------ | -------------------------------- | ---------------------------------------------------------------- |
+| Release-aware PRs        | Extraction plus hosted PR        | Production = `fix(deps)`; other audited classes = `chore(deps)`. |
+| Full extraction          | Extraction validator             | Every expected dependency source found exactly once.             |
+| Immutable Actions        | Static validator + GitHub policy | No mutable external ref; workflows pass.                         |
+| Protected delivery       | Branch API + canary PR           | Four exact checks required and enforced.                         |
+| Deterministic MCPB       | Two clean builds                 | Same locked dependency/file inventory; MCPB validation passes.   |
+| Accurate runtime support | Search + matrix                  | No stale server-18 claim; server 22/24 and CLI contract pass.    |
+| Safe automation          | Two cycles + canary              | Only eligible dev/lock PR auto-merges after four checks.         |
+| Migration closed         | Removal matrix                   | No `migrating` artifact or superseded path remains.              |
+
+### Documentation updates
+
+| Document                             | Update                                                |
+| ------------------------------------ | ----------------------------------------------------- |
+| `CLAUDE.md`                          | Canonical split Node support and validation contract. |
+| `CONTRIBUTING.md`                    | Contributor runtime matrix.                           |
+| `server/README.md`                   | Server Node floor.                                    |
+| `docs/guides/identity-scope.md`      | Deployment prerequisite.                              |
+| `docs/portfolio/design-decisions.md` | Runtime claim.                                        |
+| `docs/TODO.md`                       | Correct completed CI policy.                          |
+| `CHANGELOG.md`                       | Unreleased Changed entry.                             |
+| This plan + implementation notes     | Decisions, evidence, deviations, and removal status.  |
+
+### Risks and rollback
+
+| Risk                                    | Impact                         | Mitigation                                              | Rollback                                                                                                   |
+| --------------------------------------- | ------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Production rule loses during merge      | Missing release                | Put specific rule after defaults; assert effective type | Disable Renovate PR creation and restore last known config commit.                                         |
+| Pin uses incorrect SHA                  | Compromised or failed workflow | Verify upstream tag object and repository origin        | Revert the individual pin to the previously recorded SHA, not a mutable tag.                               |
+| Local extraction format changes         | False CI failure               | Pin Renovate and self-test parser                       | Revert Renovate bump; do not bypass the extraction gate.                                                   |
+| Locked staging omits runtime dependency | Broken MCPB                    | Required/excluded validator and unpacked smoke          | Revert packaging tier to last known artifact process while keeping MCPB exact; reopen plan before release. |
+| Four checks deadlock merge              | Blocked PRs                    | Require only recently reporting stable job names        | Restore captured before-state protection JSON, diagnose, and reapply all four before closeout.             |
+| Automerge scope widens                  | Unreviewed change              | Later explicit exclusions and hosted canary             | Set top/rule automerge false immediately; keep observation evidence.                                       |
+
+### Mandatory legacy-removal matrix
+
+| Superseded artifact                          | Delete when                                        | Proof                             | Final state |
+| -------------------------------------------- | -------------------------------------------------- | --------------------------------- | ----------- |
+| Global `chore(deps)` prefix                  | Semantic extraction assertions pass                | Production `fix`, tooling `chore` | `removed`   |
+| Generic security patch/auto-merge rule       | Vulnerability alert policy resolves correctly      | Immediate manual alert extraction | `removed`   |
+| Nonexistent category labels                  | Minimal-label config validates against live labels | Label comparison                  | `removed`   |
+| Broad MCPB/global npm regex path             | Root MCPB extraction passes                        | Exactly one npm extraction        | `removed`   |
+| Unpinned `npx @anthropic-ai/mcpb`            | Root local MCPB validates                          | Root `npm ci` + MCPB validate     | `removed`   |
+| Staged `npm install`                         | Server-lock staging builds twice                   | Equivalent inventories            | `removed`   |
+| Mutable external Action tags                 | All pins/workflows pass                            | Pin validator + CI                | `removed`   |
+| Two-check live protection                    | All four contexts have recent runs                 | Protection GET + canary           | `removed`   |
+| Collapsed Node 18–24 server claim            | Docs and matrix agree                              | Stale-claim search                | `removed`   |
+| Rollout-only eligible-rule `automerge:false` | Two-cycle guard passes and canary succeeds         | Hosted canary                     | `removed`   |
+
+### Release convention
+
+- **Commit:** `fix(deps): align Renovate with release and packaging contracts`
+- **Scope:** `deps`
+- The plan may use multiple commits by tier; production-affecting dependency semantics and packaging corrections use `fix(deps)`, while policy/docs-only follow-ups use `chore(deps)` or `docs` as appropriate.
+
+### Growth capture
+
+- [x] Capture the pattern “dependency automation is a delivery contract, not a bot config” after implementation evidence confirms it.
+- [ ] Record whether pinned local extraction remains stable across the next Renovate upgrade.
+- [x] Record the server/CLI Node support distinction in the tracked operator handbook after Phase 4 found the packaged/runtime mismatch.
+- [ ] Feed any user correction into the owning workflow skill and observation ledger immediately.
+
+## 7. Execution Notes
+
+- The working tree was dirty from another session when this plan was written. Only this new plan file was added; none of that session's files were changed.
+- Keep `plans/renovate-maintenance-remediation-2026-08-01-implementation-notes.md` beside this plan during implementation.
+- Record deviations under `## Deviations`, choose the conservative action, and update this plan before retrying a failed approach.
+- The plan is incomplete until Phase 7 and the legacy-removal matrix are complete.

--- a/scripts/build-extension.sh
+++ b/scripts/build-extension.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
-# Build Claude Desktop Extension (.mcpb) with production deps only
+# Build the Claude Desktop Extension from the server's locked production tree.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 STAGING_DIR="$ROOT_DIR/.mcpb-staging"
 OUTPUT_FILE="$ROOT_DIR/claude-prompts.mcpb"
+INSTALL_DIR="$(mktemp -d "${TMPDIR:-/tmp}/claude-prompts-mcpb-install.XXXXXX")"
+MCPB_BIN="$ROOT_DIR/node_modules/.bin/mcpb"
+MCPB_EXCLUDED_DEPS=("chokidar" "ulid")
+
+cleanup() {
+  rm -rf "$STAGING_DIR" "$INSTALL_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -x "$MCPB_BIN" ]]; then
+  echo "ERROR: MCPB CLI missing. Run 'npm ci' from the repository root." >&2
+  exit 1
+fi
 
 echo "==> Building Claude Desktop Extension"
 
-# Clean staging directory
 echo "==> Cleaning staging directory..."
 rm -rf "$STAGING_DIR"
 mkdir -p "$STAGING_DIR/server"
@@ -35,58 +47,63 @@ cp "$ROOT_DIR/server/LICENSE" "$STAGING_DIR/server/"
 # Copy skills
 cp -r "$ROOT_DIR/skills" "$STAGING_DIR/" 2>/dev/null || true
 
-# Install production dependencies only
-echo "==> Installing production dependencies..."
-cd "$STAGING_DIR/server"
+echo "==> Installing the locked production dependency tree..."
+cp "$ROOT_DIR/server/package.json" "$ROOT_DIR/server/package-lock.json" "$INSTALL_DIR/"
+if [[ -f "$ROOT_DIR/server/.npmrc" ]]; then
+  cp "$ROOT_DIR/server/.npmrc" "$INSTALL_DIR/"
+fi
+(cd "$INSTALL_DIR" && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+cp -R "$INSTALL_DIR/node_modules" "$STAGING_DIR/server/"
 
-# Read version from server/package.json
-VERSION=$(node -p "require('$ROOT_DIR/server/package.json').version")
-echo "    Version: $VERSION"
+for dependency in "${MCPB_EXCLUDED_DEPS[@]}"; do
+  rm -rf "$STAGING_DIR/server/node_modules/$dependency"
+done
 
-# Create minimal package.json with production deps read dynamically from server/package.json
-# NOTE: These deps are safety net for CJS interop - most are bundled in dist/index.js
-# SSOT: server/package.json is the source of truth; deps are filtered at build time
-echo "==> Generating package.json from server/package.json..."
-
-# Read deps dynamically, excluding packages that are bundled inline by esbuild
-DEPS=$(node -p "
-  const pkg = require('$ROOT_DIR/server/package.json');
-  // Packages bundled inline by esbuild - don't need as runtime deps
-  const exclude = ['chokidar'];
-  Object.entries(pkg.dependencies)
-    .filter(([name]) => exclude.includes(name) === false && name.startsWith('@types/') === false)
-    .map(([name, ver]) => '    \"' + name + '\": \"' + ver + '\"')
-    .join(',\n');
-")
-
-cat > package.json << EOF
-{
-  "name": "claude-prompts",
-  "version": "$VERSION",
-  "type": "module",
-  "main": "dist/index.js",
-  "dependencies": {
-$DEPS
+# npm creates relative links in .bin. Excluding a bundled package must also remove
+# its now-dangling executable link or MCPB refuses to archive the staged tree.
+node - "$STAGING_DIR/server/node_modules/.bin" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const binDir = process.argv[2];
+if (fs.existsSync(binDir)) {
+  for (const entry of fs.readdirSync(binDir)) {
+    const entryPath = path.join(binDir, entry);
+    if (fs.lstatSync(entryPath).isSymbolicLink() && !fs.existsSync(entryPath)) {
+      fs.unlinkSync(entryPath);
+    }
   }
 }
-EOF
+NODE
 
-echo "    Dependencies:"
-echo "$DEPS" | sed 's/^/      /'
+echo "==> Generating the staged package contract..."
+node - "$ROOT_DIR/server/package.json" "$STAGING_DIR/server/package.json" "${MCPB_EXCLUDED_DEPS[@]}" <<'NODE'
+const fs = require('node:fs');
+const [sourcePath, outputPath, ...excluded] = process.argv.slice(2);
+const source = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+const dependencies = Object.fromEntries(
+  Object.entries(source.dependencies).filter(([name]) => !excluded.includes(name)),
+);
+const staged = {
+  name: source.name,
+  version: source.version,
+  type: source.type,
+  main: source.main,
+  dependencies,
+};
+fs.writeFileSync(outputPath, `${JSON.stringify(staged, null, 2)}\n`);
+NODE
 
-npm install --omit=dev --ignore-scripts
+node "$ROOT_DIR/server/scripts/validate-extension-deps.js" --staging-dir "$STAGING_DIR"
 
 # Pack using mcpb
 echo "==> Packing extension..."
 cd "$STAGING_DIR"
 rm -f "$OUTPUT_FILE"
-npx @anthropic-ai/mcpb pack . "$OUTPUT_FILE"
+"$MCPB_BIN" pack . "$OUTPUT_FILE"
 
 # Show results
 echo ""
 echo "==> Build complete!"
 ls -lh "$OUTPUT_FILE"
 
-# Cleanup
-echo "==> Cleaning up staging directory..."
-rm -rf "$STAGING_DIR"
+echo "==> Cleaning up staging directories..."

--- a/server/README.md
+++ b/server/README.md
@@ -2,9 +2,11 @@
 
 [![npm version](https://img.shields.io/npm/v/claude-prompts.svg)](https://www.npmjs.com/package/claude-prompts)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18.18-brightgreen.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.13-brightgreen.svg)](https://nodejs.org/)
 
 MCP server for prompt management, thinking frameworks, and quality gates. Hot-reloads prompts, injects structured reasoning, enforces output validation—all through MCP tools Claude can call directly.
+
+The server and desktop extension require Node.js >=22.13.0 because the runtime uses `node:sqlite` without an experimental flag. The separately packaged CPM CLI supports Node.js >=18.18.0.
 
 ## Quick Start
 

--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -62,7 +62,8 @@ module.exports = {
     '^#cli-shared/(.*)\\.js$': '<rootDir>/src/cli-shared/$1',
     '^(?:\\.{1,2}/)+dist/(.*)\\.js$': '<rootDir>/src/$1',
     '^(\\.{1,2}/.*)\\.js$': '$1',
-    // node:sqlite is a native Node.js built-in (>=22); shim for Jest's module resolver
+    // node:sqlite is an unflagged Node.js built-in at the server floor (>=22.13.0);
+    // shim for Jest's module resolver
     '^node:sqlite$': '<rootDir>/tests/helpers/node-sqlite-shim.cjs'
   },
   // Transform ES modules from node_modules if needed

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -54,7 +54,7 @@
         "typescript-eslint": "^8.60.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/server/package.json
+++ b/server/package.json
@@ -114,8 +114,13 @@
     "version": "npm run sync:versions && git add ../.release-please-manifest.json ../manifest.json ../.claude-plugin/plugin.json",
     "validate:dist-fresh": "bash scripts/validate-dist-fresh.sh",
     "validate:extension-deps": "node scripts/validate-extension-deps.js",
+    "validate:extension-deps:self-test": "node scripts/validate-extension-deps.js --self-test",
+    "validate:github-action-pins": "node scripts/validate-github-action-pins.js",
+    "validate:github-action-pins:self-test": "node scripts/validate-github-action-pins.js --self-test",
+    "validate:renovate-extraction": "node scripts/validate-renovate-extraction.js",
+    "validate:renovate-extraction:self-test": "node scripts/validate-renovate-extraction.js --self-test",
     "validate:python": "cd .. && ruff check hooks/ && ruff format --check hooks/ && pyrefly check --baseline hooks/.pyrefly-baseline.json",
-    "validate:all": "npm run lint:ratchet && npm run typecheck:tests:ratchet && npm run validate:format && npm run validate:arch && npm run validate:filesize && npm run validate:metadata && npm run validate:contracts && npm run validate:python && npm run validate:frameworks && npm run validate:gate-index && npm run validate:versions && npm run validate:extension-deps && npm run validate:readme && npm run validate:no-legacy-sidecars && npm run validate:no-prompt-gates-alias && npm run validate:no-tool-layer-validator-imports && npm run validate:no-crosslayer-reexport && npm run validate:no-chainsessionmanager && npm run validate:no-stepstate && npm run validate:no-methodology-vocab && npm run validate:no-execution-mode && npm run validate:no-crosslayer-relative && npm run validate:documented-options && npm run validate:required-contexts && npm run validate:package-entries && npm run verify:mcp:self-test && npm run validate:required-contexts:self-test && npm run validate:package-entries:self-test && npm run validate:no-crosslayer-relative:self-test && npm run validate:arch:self-test",
+    "validate:all": "npm run lint:ratchet && npm run typecheck:tests:ratchet && npm run validate:format && npm run validate:arch && npm run validate:filesize && npm run validate:metadata && npm run validate:contracts && npm run validate:python && npm run validate:frameworks && npm run validate:gate-index && npm run validate:versions && npm run validate:extension-deps && npm run validate:github-action-pins && npm run validate:readme && npm run validate:no-legacy-sidecars && npm run validate:no-prompt-gates-alias && npm run validate:no-tool-layer-validator-imports && npm run validate:no-crosslayer-reexport && npm run validate:no-chainsessionmanager && npm run validate:no-stepstate && npm run validate:no-methodology-vocab && npm run validate:no-execution-mode && npm run validate:no-crosslayer-relative && npm run validate:documented-options && npm run validate:required-contexts && npm run validate:package-entries && npm run verify:mcp:self-test && npm run validate:required-contexts:self-test && npm run validate:package-entries:self-test && npm run validate:no-crosslayer-relative:self-test && npm run validate:arch:self-test && npm run validate:extension-deps:self-test && npm run validate:github-action-pins:self-test && npm run validate:renovate-extraction:self-test",
     "verify:action-metadata": "tsx scripts/verify-action-inventory.ts",
     "dev:graph": "madge --ts-config ./tsconfig.json --extensions ts src --image graph.svg",
     "dev:graph:json": "madge --ts-config ./tsconfig.json --extensions ts src --json",
@@ -124,7 +129,7 @@
     "prepublishOnly": "npm run build:prod",
     "release": "npm run build && npm test && npm publish --access public",
     "pack:mcpb": "../scripts/build-extension.sh",
-    "pack:mcpb:validate": "cd .. && npx @anthropic-ai/mcpb validate manifest.json"
+    "pack:mcpb:validate": "npm --prefix .. run mcpb:validate"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,cjs,mjs}": [
@@ -152,7 +157,7 @@
     "server"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/server/scripts/validate-extension-deps.js
+++ b/server/scripts/validate-extension-deps.js
@@ -1,158 +1,162 @@
 #!/usr/bin/env node
-/**
- * Validates that .mcpb extension dependencies are properly configured.
- *
- * Checks:
- * 1. Required deps exist in server/package.json
- * 2. Excluded deps (bundled inline by esbuild) are not leaked
- * 3. build-extension.sh exclude list matches expected bundled packages
- *
- * Run: node server/scripts/validate-extension-deps.js
- * CI: Part of validate:all
- */
+/** Validate the dependency contract used to assemble the MCPB artifact. */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT_DIR = join(__dirname, '../..');
-const SERVER_DIR = join(__dirname, '..');
+const SERVER_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = join(SERVER_DIR, '..');
+const POLICY = {
+  required: [
+    '@modelcontextprotocol/sdk',
+    '@opentelemetry/api',
+    '@opentelemetry/exporter-trace-otlp-http',
+    '@opentelemetry/resources',
+    '@opentelemetry/sdk-node',
+    '@opentelemetry/sdk-trace-node',
+    '@opentelemetry/semantic-conventions',
+    'ajv',
+    'diff',
+    'express',
+    'js-yaml',
+    'nunjucks',
+    'zod',
+  ],
+  excluded: ['chokidar', 'ulid'],
+};
 
-// Deps that SHOULD be in .mcpb (CJS interop safety net)
-// These are packages that don't bundle cleanly due to CJS/ESM interop issues
-const MCPB_REQUIRED_DEPS = [
-  '@modelcontextprotocol/sdk',
-  '@opentelemetry/api',
-  '@opentelemetry/exporter-trace-otlp-http',
-  '@opentelemetry/resources',
-  '@opentelemetry/sdk-node',
-  '@opentelemetry/sdk-trace-node',
-  '@opentelemetry/semantic-conventions',
-  'ajv',
-  'diff',
-  'express',
-  'js-yaml',
-  'nunjucks',
-  'zod',
-];
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+const sameNames = (actual, expected) =>
+  actual.length === expected.length && actual.every((name, index) => name === expected[index]);
 
-// Deps that should NOT be in .mcpb (bundled inline by esbuild)
-// Keep in sync with exclude array in build-extension.sh
-const MCPB_EXCLUDED_DEPS = [
-  'chokidar', // Bundled inline by esbuild - file watcher
-];
+function buildExclusions(script) {
+  const match = script.match(/MCPB_EXCLUDED_DEPS=\(([^)]*)\)/);
+  if (!match) throw new Error('build-extension.sh does not declare MCPB_EXCLUDED_DEPS');
+  return [...match[1].matchAll(/["']([^"']+)["']/g)].map((item) => item[1]).sort();
+}
 
-function extractBuildScriptExcludeList() {
-  const buildScript = readFileSync(join(ROOT_DIR, 'scripts/build-extension.sh'), 'utf-8');
-
-  // Extract exclude array from: const exclude = ['chokidar'];
-  const excludeMatch = buildScript.match(/const exclude = \[([^\]]+)\]/);
-  if (!excludeMatch) {
-    throw new Error('Could not find exclude array in build-extension.sh');
+function validateContract({ packageJson, packageLock, buildScript, stagedDir, policy = POLICY }) {
+  const errors = [];
+  const dependencies = packageJson.dependencies ?? {};
+  const declared = Object.keys(dependencies).sort();
+  const classified = [...policy.required, ...policy.excluded].sort();
+  if (!sameNames(declared, classified)) {
+    errors.push(
+      `dependency classification mismatch: declared=[${declared}] classified=[${classified}]`
+    );
   }
 
-  // Parse the array contents
-  const excludeList = excludeMatch[1]
-    .split(',')
-    .map((s) => s.trim().replace(/['"]/g, ''))
-    .filter((s) => s.length > 0);
+  let exclusions = [];
+  try {
+    exclusions = buildExclusions(buildScript);
+  } catch (error) {
+    errors.push(error.message);
+  }
+  if (!sameNames(exclusions, [...policy.excluded].sort())) {
+    errors.push(`build exclusions mismatch: actual=[${exclusions}] expected=[${policy.excluded}]`);
+  }
 
-  return excludeList;
+  const lockedRoot = packageLock.packages?.['']?.dependencies ?? {};
+  for (const [name, range] of Object.entries(dependencies)) {
+    if (lockedRoot[name] !== range)
+      errors.push(`lock root mismatch for ${name}: ${lockedRoot[name]}`);
+    if (!packageLock.packages?.[`node_modules/${name}`])
+      errors.push(`lock entry missing for ${name}`);
+  }
+
+  if (stagedDir) {
+    const stagedServer = join(stagedDir, 'server');
+    const stagedPackage = readJson(join(stagedServer, 'package.json'));
+    const bundle = readFileSync(join(stagedServer, 'dist', 'index.js'), 'utf8');
+    const expectedNames = [...policy.required].sort();
+    const stagedNames = Object.keys(stagedPackage.dependencies ?? {}).sort();
+    if (!sameNames(stagedNames, expectedNames)) {
+      errors.push(
+        `staged dependencies mismatch: actual=[${stagedNames}] expected=[${expectedNames}]`
+      );
+    }
+    for (const name of policy.required) {
+      if (stagedPackage.dependencies?.[name] !== dependencies[name]) {
+        errors.push(`staged range mismatch for ${name}: ${stagedPackage.dependencies?.[name]}`);
+      }
+      if (!existsSync(join(stagedServer, 'node_modules', name))) {
+        errors.push(`staged module missing for ${name}`);
+      }
+    }
+    for (const name of policy.excluded) {
+      if (existsSync(join(stagedServer, 'node_modules', name))) {
+        errors.push(`excluded module present in stage: ${name}`);
+      }
+      if (!bundle.includes(`node_modules/${name}/`)) {
+        errors.push(`excluded module is not proven bundled: ${name}`);
+      }
+    }
+  }
+  return errors;
+}
+
+function runSelfTest() {
+  const fixture = mkdtempSync(join(tmpdir(), 'extension-deps-test-'));
+  const stage = join(fixture, 'stage', 'server');
+  const policy = { required: ['runtime'], excluded: ['bundled'] };
+  const packageJson = { dependencies: { runtime: '^1.0.0', bundled: '^2.0.0' } };
+  const packageLock = {
+    packages: {
+      '': { dependencies: packageJson.dependencies },
+      'node_modules/runtime': {},
+      'node_modules/bundled': {},
+    },
+  };
+  const buildScript = 'MCPB_EXCLUDED_DEPS=("bundled")';
+  mkdirSync(join(stage, 'node_modules', 'runtime'), { recursive: true });
+  mkdirSync(join(stage, 'dist'), { recursive: true });
+  writeFileSync(join(stage, 'dist', 'index.js'), '// node_modules/bundled/index.js');
+  writeFileSync(
+    join(stage, 'package.json'),
+    JSON.stringify({ dependencies: { runtime: '^1.0.0' } })
+  );
+  const validate = (overrides = {}) =>
+    validateContract({
+      packageJson,
+      packageLock,
+      buildScript,
+      stagedDir: join(fixture, 'stage'),
+      policy,
+      ...overrides,
+    });
+  try {
+    if (validate().length) throw new Error('healthy fixture failed');
+    if (!validate({ packageLock: { packages: {} } }).length) throw new Error('bad lock passed');
+    if (!validate({ buildScript: 'MCPB_EXCLUDED_DEPS=("other")' }).length) {
+      throw new Error('bad exclusion passed');
+    }
+    rmSync(join(stage, 'node_modules', 'runtime'), { recursive: true });
+    if (!validate().length) throw new Error('bad stage passed');
+    console.log('PASSED: extension dependency validator self-test');
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
 }
 
 function main() {
-  const serverPkg = JSON.parse(readFileSync(join(SERVER_DIR, 'package.json'), 'utf-8'));
-  const serverDeps = serverPkg.dependencies;
-
-  let hasErrors = false;
-  let hasWarnings = false;
-
-  console.log('Validating .mcpb extension dependencies...\n');
-
-  // Check 1: Required deps exist in server/package.json
-  console.log('Checking required deps exist in server/package.json:');
-  for (const dep of MCPB_REQUIRED_DEPS) {
-    if (!serverDeps[dep]) {
-      console.error(`  ERROR: ${dep} required for .mcpb but missing from server/package.json`);
-      hasErrors = true;
-    } else {
-      console.log(`  ✓ ${dep}: ${serverDeps[dep]}`);
-    }
+  if (process.argv.includes('--self-test')) return runSelfTest();
+  const stageIndex = process.argv.indexOf('--staging-dir');
+  const stagedDir = stageIndex === -1 ? undefined : process.argv[stageIndex + 1];
+  if (stageIndex !== -1 && !stagedDir) throw new Error('--staging-dir requires a path');
+  const errors = validateContract({
+    packageJson: readJson(join(SERVER_DIR, 'package.json')),
+    packageLock: readJson(join(SERVER_DIR, 'package-lock.json')),
+    buildScript: readFileSync(join(ROOT_DIR, 'scripts/build-extension.sh'), 'utf8'),
+    stagedDir,
+  });
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+    return;
   }
-
-  // Check 2: Excluded deps should be in package.json (so they're bundled)
-  console.log('\nChecking excluded deps are in package.json (for bundling):');
-  for (const dep of MCPB_EXCLUDED_DEPS) {
-    if (!serverDeps[dep]) {
-      console.warn(`  WARNING: ${dep} not in server/package.json - is it still used?`);
-      hasWarnings = true;
-    } else {
-      console.log(`  ✓ ${dep}: ${serverDeps[dep]} (bundled inline, excluded from .mcpb)`);
-    }
-  }
-
-  // Check 3: build-extension.sh exclude list matches our expected list
-  console.log('\nChecking build-extension.sh exclude list:');
-  try {
-    const buildExcludeList = extractBuildScriptExcludeList();
-
-    // Check all expected excludes are in build script
-    for (const dep of MCPB_EXCLUDED_DEPS) {
-      if (!buildExcludeList.includes(dep)) {
-        console.error(`  ERROR: ${dep} should be in build-extension.sh exclude list`);
-        hasErrors = true;
-      }
-    }
-
-    // Check for unexpected excludes in build script
-    for (const dep of buildExcludeList) {
-      if (!MCPB_EXCLUDED_DEPS.includes(dep)) {
-        console.warn(`  WARNING: ${dep} in build-extension.sh exclude but not in expected list`);
-        hasWarnings = true;
-      }
-    }
-
-    if (!hasErrors && buildExcludeList.length === MCPB_EXCLUDED_DEPS.length) {
-      console.log(`  ✓ Exclude list matches: [${buildExcludeList.join(', ')}]`);
-    }
-  } catch (error) {
-    console.error(`  ERROR: ${error.message}`);
-    hasErrors = true;
-  }
-
-  // Check 4: Warn about new deps that might need consideration
-  console.log('\nChecking for new deps that might need review:');
-  const allDeps = Object.keys(serverDeps);
-  const knownDeps = [...MCPB_REQUIRED_DEPS, ...MCPB_EXCLUDED_DEPS];
-  const unknownDeps = allDeps.filter(
-    (dep) => !knownDeps.includes(dep) && !dep.startsWith('@types/')
-  );
-
-  if (unknownDeps.length > 0) {
-    console.warn('  New dependencies found - review if they should be:');
-    console.warn('  - Added to MCPB_REQUIRED_DEPS (needs CJS interop at runtime)');
-    console.warn('  - Added to MCPB_EXCLUDED_DEPS (bundled inline by esbuild)');
-    for (const dep of unknownDeps) {
-      console.warn(`  ? ${dep}: ${serverDeps[dep]}`);
-    }
-    hasWarnings = true;
-  } else {
-    console.log('  ✓ No unknown dependencies');
-  }
-
-  // Summary
-  console.log('\n' + '='.repeat(50));
-  if (hasErrors) {
-    console.error('FAILED: Extension dependency validation has errors');
-    process.exit(1);
-  } else if (hasWarnings) {
-    console.warn('PASSED with warnings: Review the warnings above');
-    process.exit(0);
-  } else {
-    console.log('PASSED: Extension dependencies validated successfully');
-    process.exit(0);
-  }
+  console.log(`PASSED: MCPB dependency contract${stagedDir ? ' and staged tree' : ''}`);
 }
 
 main();

--- a/server/scripts/validate-github-action-pins.js
+++ b/server/scripts/validate-github-action-pins.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/** Enforce immutable external GitHub Action refs with readable release comments. */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SERVER_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = join(SERVER_DIR, '..');
+const ACTION_ROOTS = ['.github/actions', '.github/workflows'];
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const VERSION_COMMENT_PATTERN = /^v\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?$/;
+const USES_PATTERN =
+  /^\s*(?:-\s*)?uses:\s*(?:"([^"]+)"|'([^']+)'|([^\s#]+))\s*(?:#\s*(\S(?:.*\S)?))?\s*$/;
+
+function yamlFiles(directory) {
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return yamlFiles(path);
+    return /\.ya?ml$/.test(entry.name) ? [path] : [];
+  });
+}
+
+function validateUsesLine(line) {
+  if (!/^\s*(?:-\s*)?uses:/.test(line)) return { external: false, errors: [] };
+  const match = line.match(USES_PATTERN);
+  if (!match) return { external: true, errors: ['malformed uses reference'] };
+  const reference = match[1] ?? match[2] ?? match[3];
+  const comment = match[4];
+  if (reference.startsWith('./')) return { external: false, errors: [] };
+
+  const separator = reference.lastIndexOf('@');
+  const sha = separator === -1 ? '' : reference.slice(separator + 1);
+  const errors = [];
+  if (!SHA_PATTERN.test(sha)) errors.push('external ref must be a 40-character lowercase SHA');
+  if (!comment || !VERSION_COMMENT_PATTERN.test(comment)) {
+    errors.push('external ref must have a same-line release comment such as # v4.2.0');
+  }
+  return { external: true, errors };
+}
+
+function validateRepository(rootDir = ROOT_DIR) {
+  const files = ACTION_ROOTS.flatMap((directory) => yamlFiles(join(rootDir, directory))).sort();
+  const errors = [];
+  let externalCount = 0;
+  for (const file of files) {
+    for (const [index, line] of readFileSync(file, 'utf8').split(/\r?\n/).entries()) {
+      const result = validateUsesLine(line);
+      if (result.external) externalCount += 1;
+      for (const error of result.errors) {
+        errors.push(`${relative(rootDir, file)}:${index + 1}: ${error}`);
+      }
+    }
+  }
+  return { errors, externalCount, fileCount: files.length };
+}
+
+function runSelfTest() {
+  const sha = 'a'.repeat(40);
+  const healthy = [
+    `      uses: owner/action@${sha} # v4.2.0`,
+    `      uses: owner/action/subpath@${sha} # v1`,
+    '      uses: ./.github/actions/local',
+  ];
+  const unhealthy = [
+    '      uses: owner/action@v4',
+    `      uses: owner/action@${sha.toUpperCase()} # v4.2.0`,
+    `      uses: owner/action@${sha}`,
+    `      uses: owner/action@${sha} # latest release`,
+    '      uses: "unterminated',
+  ];
+  if (healthy.some((line) => validateUsesLine(line).errors.length > 0)) {
+    throw new Error('healthy Action pin fixture failed');
+  }
+  if (unhealthy.some((line) => validateUsesLine(line).errors.length === 0)) {
+    throw new Error('mutable or malformed Action fixture passed');
+  }
+  console.log('PASSED: GitHub Action pin validator self-test');
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) return runSelfTest();
+  const result = validateRepository();
+  if (result.fileCount === 0) result.errors.push('no GitHub Action YAML files found');
+  if (result.errors.length > 0) {
+    for (const error of result.errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `PASSED: ${result.externalCount} external Action references pinned across ${result.fileCount} YAML files`
+  );
+}
+
+main();

--- a/server/scripts/validate-renovate-extraction.js
+++ b/server/scripts/validate-renovate-extraction.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/** Validate Renovate's resolved policy and dependency extraction JSONL. */
+
+import { readFileSync } from 'node:fs';
+
+const ACTION_FILES = [
+  '.github/actions/setup-node-install/action.yml',
+  '.github/workflows/ci.yml',
+  '.github/workflows/downstream-sync.yml',
+  '.github/workflows/extension-publish.yml',
+  '.github/workflows/npm-publish.yml',
+  '.github/workflows/release-please.yml',
+  '.github/workflows/renovate-config-validator.yml',
+];
+const PACKAGE_FILES = ['cli/package.json', 'package.json', 'server/package.json'];
+const EXPECTED_COUNTS = { 'github-actions': 7, nodenv: 1, npm: 3, regex: 3 };
+const RULES = [
+  ['Default dependency PRs remain maintenance-only', { semanticCommitType: 'chore' }],
+  ['Server runtime dependencies trigger patch releases', { semanticCommitType: 'fix' }],
+  ['Isolate major updates for manual review', { groupName: null }],
+  ['TypeScript - require manual review', { groupName: 'TypeScript' }],
+  ['MCP SDK - critical dependency', { groupName: 'MCP SDK' }],
+  ['GitHub Actions - one executable supply-chain boundary', { groupName: 'GitHub Actions' }],
+  ['Pinned Python validation tools', { groupName: 'Python validation tools' }],
+];
+
+const same = (actual, expected) => JSON.stringify(actual) === JSON.stringify(expected);
+const sorted = (values) => [...values].sort();
+
+function parseJsonLines(input) {
+  const lines = input.split(/\r?\n/).filter((line) => line.trim());
+  if (!lines.length) throw new Error('Renovate emitted no JSONL records');
+  return lines.map((line, index) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      throw new Error(`Renovate emitted non-JSON output on line ${index + 1}`);
+    }
+  });
+}
+
+function onlyRecord(rows, message, errors) {
+  const matches = rows.filter((row) => row.msg === message);
+  if (matches.length !== 1)
+    errors.push(`expected one '${message}' record, found ${matches.length}`);
+  return matches[0];
+}
+
+function validateConfig(config, errors) {
+  if (!same(config.labels, ['dependencies'])) errors.push('resolved labels must be [dependencies]');
+  if (config.automerge !== false || config.platformAutomerge !== false) {
+    errors.push('resolved automerge policy must remain disabled');
+  }
+  if (!same(config.schedule, ['* 0-5 * * 1'])) errors.push('resolved maintenance schedule changed');
+  const alerts = config.vulnerabilityAlerts ?? {};
+  if (!same(alerts.addLabels, ['security', 'vulnerability']) || alerts.automerge !== false) {
+    errors.push('resolved vulnerability label/automerge policy changed');
+  }
+  const rules = config.packageRules ?? [];
+  const indexes = new Map();
+  for (const [description, expected] of RULES) {
+    const index = rules.findIndex((rule) => rule.description?.includes(description));
+    indexes.set(description, index);
+    if (index === -1) {
+      errors.push(`resolved rule missing: ${description}`);
+      continue;
+    }
+    for (const [field, value] of Object.entries(expected)) {
+      if (!same(rules[index][field], value)) errors.push(`${description} has unexpected ${field}`);
+    }
+  }
+  if (indexes.get(RULES[0][0]) >= indexes.get(RULES[1][0])) {
+    errors.push('default semantic rule must precede the server runtime override');
+  }
+}
+
+function validateExtraction(stats, extracted, errors) {
+  for (const [manager, count] of Object.entries(EXPECTED_COUNTS)) {
+    if (stats.managers?.[manager]?.fileCount !== count) {
+      errors.push(`${manager} fileCount must be ${count}`);
+    }
+  }
+  const managerNames = Object.keys(stats.managers ?? {}).sort();
+  if (!same(managerNames, Object.keys(EXPECTED_COUNTS).sort()))
+    errors.push('unexpected extracted manager set');
+
+  const files = (manager) => sorted((extracted[manager] ?? []).map((entry) => entry.packageFile));
+  if (!same(files('github-actions'), sorted(ACTION_FILES)))
+    errors.push('GitHub Actions file inventory changed');
+  if (!same(files('npm'), sorted(PACKAGE_FILES))) errors.push('npm package file inventory changed');
+  if (!same(files('nodenv'), ['.node-version'])) errors.push('Node version source changed');
+
+  const dependencies = Object.entries(extracted)
+    .filter(([, entries]) => Array.isArray(entries))
+    .flatMap(([manager, entries]) =>
+      entries.flatMap((entry) =>
+        entry.deps.map((dependency) => ({ manager, file: entry.packageFile, ...dependency }))
+      )
+    );
+  const mcpb = dependencies.filter((dependency) => dependency.depName === '@anthropic-ai/mcpb');
+  if (
+    mcpb.length !== 1 ||
+    mcpb[0].manager !== 'npm' ||
+    mcpb[0].file !== 'package.json' ||
+    mcpb[0].currentValue !== '2.1.2'
+  ) {
+    errors.push('MCPB must be extracted exactly once from root package.json at 2.1.2');
+  }
+  const regexDeps = dependencies
+    .filter((dependency) => dependency.manager === 'regex')
+    .map((dependency) => `${dependency.depName}@${dependency.currentValue}`)
+    .sort();
+  if (!same(regexDeps, ['pyrefly@1.1.1', 'renovate@44.6.0', 'ruff@0.16.0'])) {
+    errors.push(`custom-manager identities changed: [${regexDeps}]`);
+  }
+}
+
+function validateRows(rows) {
+  const errors = rows
+    .filter((row) => Number(row.level) >= 40)
+    .map((row) => `Renovate warning/error: ${row.msg ?? 'unknown message'}`);
+  const configRow = onlyRecord(
+    rows,
+    'Full resolved config and hostRules including presets',
+    errors
+  );
+  const statsRow = onlyRecord(rows, 'Dependency extraction complete', errors);
+  const extractionRow = onlyRecord(rows, 'Extracted dependencies', errors);
+  if (configRow) validateConfig(configRow.config ?? {}, errors);
+  if (statsRow && extractionRow) {
+    validateExtraction(statsRow.stats ?? {}, extractionRow.packageFiles ?? {}, errors);
+  }
+  return errors;
+}
+
+function fixtureRows() {
+  const emptyEntries = (files) => files.map((packageFile) => ({ packageFile, deps: [] }));
+  const packageEntries = emptyEntries(PACKAGE_FILES);
+  packageEntries[1].deps.push({ depName: '@anthropic-ai/mcpb', currentValue: '2.1.2' });
+  const regex = ['ruff@0.16.0', 'pyrefly@1.1.1', 'renovate@44.6.0'].map((value) => {
+    const [depName, currentValue] = value.split('@');
+    return { packageFile: 'fixture', deps: [{ depName, currentValue }] };
+  });
+  const config = {
+    labels: ['dependencies'],
+    automerge: false,
+    platformAutomerge: false,
+    schedule: ['* 0-5 * * 1'],
+    vulnerabilityAlerts: { addLabels: ['security', 'vulnerability'], automerge: false },
+    packageRules: RULES.map(([description, expected]) => ({
+      description: [description],
+      ...expected,
+    })),
+  };
+  const managers = Object.fromEntries(
+    Object.entries(EXPECTED_COUNTS).map(([manager, fileCount]) => [manager, { fileCount }])
+  );
+  return [
+    { msg: 'Full resolved config and hostRules including presets', config },
+    { msg: 'Dependency extraction complete', stats: { managers } },
+    {
+      msg: 'Extracted dependencies',
+      packageFiles: {
+        'github-actions': emptyEntries(ACTION_FILES),
+        nodenv: emptyEntries(['.node-version']),
+        npm: packageEntries,
+        regex,
+      },
+    },
+  ];
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) {
+    const fixture = fixtureRows();
+    for (const input of ['', '{']) {
+      try {
+        parseJsonLines(input);
+        throw new Error('invalid JSONL passed');
+      } catch (error) {
+        if (error.message === 'invalid JSONL passed') throw error;
+      }
+    }
+    if (validateRows(fixture).length) throw new Error('healthy extraction fixture failed');
+    if (!validateRows([...fixture, { level: 40, msg: 'warning' }]).length)
+      throw new Error('warning passed');
+    fixture[2].packageFiles.npm[1].deps = [];
+    if (!validateRows(fixture).length) throw new Error('missing MCPB passed');
+    console.log('PASSED: Renovate extraction validator self-test');
+    return;
+  }
+  const errors = validateRows(parseJsonLines(readFileSync(0, 'utf8')));
+  if (errors.length) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exitCode = 1;
+  } else console.log('PASSED: Renovate policy and extraction contract');
+}
+
+main();

--- a/server/tests/helpers/node-sqlite-shim.cjs
+++ b/server/tests/helpers/node-sqlite-shim.cjs
@@ -1,4 +1,4 @@
-// Jest CJS resolver shim for node:sqlite (native built-in, Node >= 22)
+// Jest CJS resolver shim for node:sqlite (unflagged at Node >=22.13.0)
 // Jest's module resolver strips the node: protocol prefix, causing resolution failure.
 // Jest's sandbox also intercepts require() and createRequire(), so we use
 // Module._load() directly to bypass Jest's module system entirely.


### PR DESCRIPTION
## Summary

- align Renovate grouping, semantic commit types, labels, schedules, extraction, and lock-file policy with the server delivery contract
- pin all external GitHub Actions to full commit SHAs and add repository validators/self-tests
- align server Node support, packaging, CI, required checks, and operator documentation

## Phase 6 safety boundary

- based on merged GitHub `main` (`67e905e4`)
- exactly one implementation commit and 28 changed files
- excludes the subsequent pipeline Tier 7 plan commit (`5e1bd19f`)
- full-SHA repository enforcement remains disabled until this PR passes its pre-policy hosted checks

## Local validation

- root and server clean installs
- server typecheck and lint ratchet
- test typecheck ratchet and 145 suites / 1,754 tests
- `npm run validate:all`
- required-context and Action-pin validators/self-tests (41 pinned refs)
- Renovate 44.6.0 strict validation and extraction contract under Node 24.15.0
- MCPB schema, locked build, staged dependency contract, and packed validation

## Hosted rollout

1. Require all affected workflows and the four protected checks to pass with SHA enforcement disabled.
2. Enable `sha_pinning_required` while preserving the existing Actions permission settings.
3. Rerun this PR's workflows; roll the boolean back immediately if enforcement exposes a failure.
4. Merge through protected `main` using a merge commit.
5. Trigger hosted Renovate and inspect its dashboard/job/representative PR before Phase 7.
