### PR TITLE
Registry publish: fork guard, idempotent re-runs, verify path fix

### DIFF
--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -49,20 +49,38 @@ jobs:
           sudo install -m 0755 mcp-publisher /usr/local/bin/mcp-publisher
           mcp-publisher --version
 
+      - name: Skip if the registry already serves this version
+        id: precheck
+        run: |
+          set -euo pipefail
+          expected=$(jq -r .version server.json)
+          name=$(jq -r .name server.json)
+          got=$(curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=${name}" \
+            | jq -r --arg n "$name" '[.servers[]?.server | select(.name == $n)][0].version // empty') || got=""
+          if [ "$got" = "$expected" ]; then
+            echo "Registry already serves ${name}@${expected} — nothing to publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Authenticate via OIDC
+        if: steps.precheck.outputs.skip != 'true'
         run: mcp-publisher login github-oidc
 
       - name: Publish server.json
+        if: steps.precheck.outputs.skip != 'true'
         run: mcp-publisher publish
 
       - name: Verify the listing serves this version
+        if: steps.precheck.outputs.skip != 'true'
         run: |
           set -euo pipefail
           expected=$(jq -r .version server.json)
           name=$(jq -r .name server.json)
           for attempt in 1 2 3 4 5; do
             got=$(curl -fsS "https://registry.modelcontextprotocol.io/v0/servers?search=${name}" \
-              | jq -r --arg n "$name" '[.servers[]? | select(.name == $n)][0].version // empty') || got=""
+              | jq -r --arg n "$name" '[.servers[]?.server | select(.name == $n)][0].version // empty') || got=""
             if [ "$got" = "$expected" ]; then
               echo "Registry serves ${name}@${got}"
               exit 0

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -23,9 +23,14 @@ env:
 
 jobs:
   registry-publish:
+    # The repository guard is fork courtesy, not security: a fork's OIDC token
+    # carries its own owner, so the registry would reject its attempt to publish
+    # io.github.minipuft/* anyway — this just skips cleanly instead of failing
+    # with a confusing namespace error in someone else's Actions tab.
     if: >-
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-      || github.event_name == 'workflow_dispatch'
+      github.repository == 'minipuft/claude-prompts-mcp'
+      && ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Three hardening commits for `registry-publish.yml` after the first live cycle:

- **Fork guard** (courtesy skip — a fork's OIDC identity can't publish our namespace anyway)
- **Idempotent re-dispatch**: precheck treats 'registry already serves this version' as success; the first publish (owner-local) beat the CI dispatch and turned it red on 'duplicate version'
- **Verify jq path fix**: the live API nests payloads under `.servers[].server`; the original path would have failed verification even after a genuine publish

Registry listing is live: `io.github.minipuft/claude-prompts-mcp@3.2.1`, active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)