### PR TITLE
fix(release): synchronize Agent Plugins manifest

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -41,6 +41,11 @@
     },
     {
       "type": "json",
+      "path": "plugin.json",
+      "jsonpath": "$.version"
+    },
+    {
+      "type": "json",
       "path": "server.json",
       "jsonpath": "$.version"
     },

--- a/server/package.json
+++ b/server/package.json
@@ -118,7 +118,7 @@
     "prepare:release-artifacts": "node scripts/prepare-release-artifacts.js",
     "prepare:release-artifacts:self-test": "node scripts/prepare-release-artifacts.js --self-test",
     "sync:versions": "node scripts/sync-versions.js",
-    "version": "npm run sync:versions && git add ../package.json ../.release-please-manifest.json ../manifest.json ../.claude-plugin/plugin.json ../server.json",
+    "version": "npm run sync:versions && git add ../package.json ../.release-please-manifest.json ../manifest.json ../.claude-plugin/plugin.json ../plugin.json ../server.json",
     "validate:extension-artifact": "node scripts/validate-extension-artifact.js",
     "validate:extension-artifact:self-test": "node scripts/validate-extension-artifact.js --self-test",
     "validate:github-action-pins": "node scripts/validate-github-action-pins.js",

--- a/server/scripts/sync-versions.js
+++ b/server/scripts/sync-versions.js
@@ -21,6 +21,7 @@ const manifests = [
   { path: join(repoRoot, 'package.json'), key: 'version' },
   { path: join(repoRoot, 'manifest.json'), key: 'version' },
   { path: join(repoRoot, '.claude-plugin', 'plugin.json'), key: 'version' },
+  { path: join(repoRoot, 'plugin.json'), key: 'version' },
   { path: join(repoRoot, '.release-please-manifest.json'), key: '.' },
 ];
 


### PR DESCRIPTION
## Summary
- register the root Agent Plugins manifest as a Release Please extra file
- include it in manual version synchronization and npm version staging
- prevent the 3.3.0 release candidate from carrying a stale 3.2.1 plugin version

## Validation
- `git diff --check`
- `cd server && npm run sync:versions` (0 changes at 3.2.1)
- `cd server && npm run validate:versions -- --skip-npm`

## Release boundary
This repairs release preparation only. Merging this PR will regenerate release PR #201; #201 remains unmerged until its 3.3.0 candidate is fully validated.