### PR TITLE
fix(release): accept Release Please manifest formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@
 CHANGELOG.md
 manifest.json
 .claude-plugin/plugin.json
+plugin.json
 
 # Written by pyrefly (`validate:python` regenerates it with --baseline). It emits no
 # trailing newline, which prettier requires — so the file oscillates between the two


### PR DESCRIPTION
## Summary
- exclude the root Agent Plugins manifest from Prettier, alongside the other Release Please-owned manifests
- preserve the existing ownership rule: the release bot serializes versioned manifests; schema and version validators still enforce their content
- unblock release PR #201 after adding `plugin.json` to Release Please

## Validation
- `git diff --check`
- `cd server && npm run validate:format`

## Root cause
Release Please's JSON updater expands the keywords array, while Prettier collapses it. The existing `.prettierignore` already handles this non-convergent writer boundary for the other Release Please manifests.