### PR TITLE
fix(ci): consume repository-standards v1.3.0 so retirement stops restyling docs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Retire finished plans
         if: steps.release.outputs.pr && steps.release.outputs.release_created != 'true'
-        uses: minipuft/repository-standards/actions/retire-plans@d8cf765790dada41e03bfda4d2e533d5a0d23706 # v1.2.0
+        uses: minipuft/repository-standards/actions/retire-plans@860df1a9b9ba68c25dafbc6c175548c9d343b7dc # v1.3.0
         with:
           mode: apply
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -32,7 +32,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@minipuft/repository-standards-validation": "https://github.com/minipuft/repository-standards/archive/refs/tags/v1.2.1.tar.gz",
+        "@minipuft/repository-standards-validation": "https://github.com/minipuft/repository-standards/archive/refs/tags/v1.3.0.tar.gz",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.5.0",
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/@minipuft/repository-standards-validation": {
-      "version": "1.2.1",
-      "resolved": "https://github.com/minipuft/repository-standards/archive/refs/tags/v1.2.1.tar.gz",
-      "integrity": "sha512-tmGc5N1hvOr3rOWjAzEqOyCuOkT3nIgRLLO7My+B6O+MEGqya4Uc7FnP/aFycdZ1z1VfNF3hqOZ8XPwA2EjQ/A==",
+      "version": "1.3.0",
+      "resolved": "https://github.com/minipuft/repository-standards/archive/refs/tags/v1.3.0.tar.gz",
+      "integrity": "sha512-LhUGQfCYSwDvW8TkVRXANzUrf8uY5AYoX+qGvQhSDIxd/UKchcGJIwf+aQpJzDPK50Fdni02yD1p93fn4fMoJg==",
       "dev": true,
       "bin": {
         "retire-done-plans": "bin/retire-done-plans.cjs"

--- a/server/package.json
+++ b/server/package.json
@@ -221,7 +221,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@minipuft/repository-standards-validation": "https://github.com/minipuft/repository-standards/archive/refs/tags/v1.2.1.tar.gz",
+    "@minipuft/repository-standards-validation": "https://github.com/minipuft/repository-standards/archive/refs/tags/v1.3.0.tar.gz",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

Unblocks the 4.0.0 release PR.

The plan-retirement step wired into `release-please.yml` by #209 ran for the first time on the 4.0.0 release PR and **failed it**. Its link rewriter recomputed every relative link in every scanned document — not just links whose target moved — prepending `./` to bare sibling paths. That reflowed four markdown tables, failed `validate:format`, and cascaded into `Build` and `Test Suite` through their prerequisite assertions.

Fixed upstream in [repository-standards #10](https://github.com/minipuft/repository-standards/pull/10), released as `v1.3.0`.

## Notes for Reviewers

- **Both pins move together** because both point at that tooling: the `retire-plans` action SHA in `release-please.yml` and the `@minipuft/repository-standards-validation` tarball in `server/package.json`. Neither would have picked the fix up on its own — they are immutable by design, which is exactly why upstream `main` moving was invisible here.
- `v1.3.0` also carries the marketplace contract capability from #9: a contract may declare several entries, and a ref-tracked entry may omit its `version`.
- After this lands, Release Please regenerates the release branch and the retirement step re-applies with the fixed rewriter.

## Validation

- `validate:all` **37/37** against the installed v1.3.0
- Verified against a clone of `main`: `--apply` now touches only the moved files, and the four previously-failing files are `prettier --check` clean
- Falsified — genuine re-basing still works: same-directory citations become `./reference/<plan>.md`, and `../plans/<plan>.md` from another directory becomes `../plans/reference/<plan>.md`

Generated with Claude Code