### PR TITLE
docs(docs): correct the origin SHA in the phase-guard plan

### DIFF
--- a/plans/phase-guard-declaration-contract-2026-08-15.md
+++ b/plans/phase-guard-declaration-contract-2026-08-15.md
@@ -13,7 +13,7 @@ tags:
 **Area**: `server/src/engine/frameworks/phase-guards/`, `server/src/engine/execution/operators/chain-operator-executor.ts`, `resources/frameworks/*/phases.yaml`
 **Work type**: feature (secondary: bug_fix)
 **Confidence**: high — the defect reproduced on this plan's own authoring chain
-**Origin**: supersession review of the abandoned branch `feat/output-contract-unified-surface` (tip `f6da0841`… no — branch tip was 2026-05-13; deleted 2026-08-15 after its idea was captured here)
+**Origin**: supersession review of the abandoned branch `feat/output-contract-unified-surface` (tip `d11a0c27`, last commit 2026-05-13; deleted 2026-08-15 once its idea was captured here)
 
 ---
 


### PR DESCRIPTION
## Summary

One-line correction. The plan's `Origin` line carried a drafting artifact and cited the wrong SHA — `f6da0841` is the **execution-ledger** branch tip, not this one. The correct tip of `feat/output-contract-unified-surface` was `d11a0c27`.

## Notes for Reviewers

Opened as a PR rather than pushed directly, because the parent commit went to `main` directly by accident. `ci-release.md` states "No direct push to main — PRs even for small changes", and the push succeeded only through admin bypass.

Generated with Claude Code