### PR TITLE
feat(ci): assert the release landed downstream, not just that it was sent

### DIFF
--- a/.github/workflows/downstream-sync-audit.yml
+++ b/.github/workflows/downstream-sync-audit.yml
@@ -1,0 +1,60 @@
+name: Downstream Sync Audit
+
+# Asserts the FLEET, which no release-time gate does.
+#
+# `extension-publish.yml`'s sync-downstream job validates each downstream hard and then ends at
+# `gh pr merge --auto`. Auto-merge lands the PR when the DOWNSTREAM'S CI passes — so a downstream
+# whose CI fails, or whose sync PR is closed, stays on the old engine while the upstream release
+# is already green. That gap is invisible from upstream by construction.
+#
+# Scheduled rather than chained onto the release: the answer this asks ("did it land") is not
+# knowable at release time, because auto-merge has not resolved yet. A post-release run would
+# either block the release on four other repositories' CI or report a pending state as success.
+# A daily read answers it once it IS knowable, and `--grace-hours` keeps release day quiet.
+on:
+  schedule:
+    # 09:00 UTC daily. Four API reads; the cost of asking more often is not the API, it is that a
+    # check firing into an unresolved auto-merge window trains its own signal to be ignored.
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to assert downstream (default: latest published release)"
+        required: false
+      grace_hours:
+        description: "Hours after publication before drift is blocking (default 24)"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    # Fork courtesy: a fork auditing this repo's downstreams reports on repositories it does not
+    # own, which is noise in someone else's Actions tab rather than a finding.
+    if: github.repository == 'minipuft/claude-prompts-mcp'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      # Proves the grader can still fail before trusting a green fleet read. The check is a
+      # relation between repositories, so nothing else in CI exercises it.
+      - name: Self-test the auditor
+        working-directory: server
+        run: npm run verify:downstream-sync:self-test
+
+      - name: Audit downstream sync state
+        working-directory: server
+        env:
+          # The DEFAULT token on purpose, never RELEASE_PLEASE_TOKEN. That PAT going stale is one
+          # of the conditions this audit exists to detect — authenticating with it would make the
+          # detector fail in the same breath as its subject. Every downstream is public.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          npm run verify:downstream-sync -- \
+            ${{ inputs.version && format('--version {0}', inputs.version) || '' }} \
+            --grace-hours ${{ inputs.grace_hours || '24' }}

--- a/docs/guides/release-process.md
+++ b/docs/guides/release-process.md
@@ -114,6 +114,35 @@ Drift is watched centrally rather than per-repo: `minipuft/repository-standards`
 `Fleet Drift Audit` over the repositories listed in its `fleet.json`, comparing each one's resolved
 `node_modules/claude-prompts` version against this repository's published version.
 
+### Did it land, or was it only sent?
+
+Every gate above answers "we sent it". `sync-downstream` ends at `gh pr merge --auto`, and
+auto-merge lands the PR **when the downstream's own CI passes** — so a downstream whose CI fails,
+or whose sync PR is closed, stays on the old engine while the upstream release is already green.
+`fail-fast: false` gives the same silence to a leg that never got that far: the v4.0.0 run failed
+`codex-prompts` on a token permission while the other three synced, and the only signal was a
+workflow-level red indistinguishable from "the release broke".
+
+`Downstream Sync Audit` (`.github/workflows/downstream-sync-audit.yml`, daily) reads the **landed**
+state instead — the marketplace listing version for `minipuft-plugins`, the resolved lockfile
+version for the npm consumers — and fails when one is behind the published release. Two properties
+are load-bearing:
+
+- It derives its target list from `extension-publish.yml`'s sync matrix, so a downstream added
+  there cannot be silently unaudited. A downstream with no declared probe is an error, never a
+  skip.
+- It authenticates with the **default** workflow token, never `RELEASE_PLEASE_TOKEN`. That PAT
+  going stale is one of the conditions the audit detects, and a detector that dies with its
+  subject reports nothing.
+
+`--grace-hours` (default 24) keeps release day quiet, because auto-merge has legitimately not
+resolved yet. An **unreadable** downstream is reported regardless of the grace window — that is not
+"not landed yet", it is "this audit cannot see this repository".
+
+This overlaps the Fleet Drift Audit on resolved version and is deliberately not merged into it:
+`fleet.json` is a hand-maintained list in another repository and currently omits `codex-prompts`
+entirely, which is how the one downstream that actually failed a sync had no drift coverage.
+
 ---
 
 ## Workflow Chain

--- a/server/package.json
+++ b/server/package.json
@@ -126,6 +126,8 @@
     "validate:release-workflow": "node scripts/validate-release-workflow.js",
     "validate:release-workflow:self-test": "node scripts/validate-release-workflow.js --self-test",
     "validate:downstream-lock-sync:self-test": "node scripts/synchronize-downstream-lock.js --self-test",
+    "verify:downstream-sync": "node scripts/verify-downstream-sync.js",
+    "verify:downstream-sync:self-test": "node scripts/verify-downstream-sync.js --self-test",
     "validate:renovate-extraction": "node scripts/validate-renovate-extraction.js",
     "validate:renovate-extraction:self-test": "node scripts/validate-renovate-extraction.js --self-test",
     "validate:push-scope:self-test": "node ../scripts/classify-validation-scope.js --self-test",

--- a/server/scripts/lib/downstream-matrix.js
+++ b/server/scripts/lib/downstream-matrix.js
@@ -1,0 +1,46 @@
+/**
+ * One parse of `extension-publish.yml`'s downstream sync matrix, for every check that needs it.
+ *
+ * The matrix is the SSOT for WHO gets synced on a release. Two checks now read it —
+ * `validate-release-workflow.js` (is each entry's merge contract explicit) and
+ * `verify-downstream-sync.js` (did each entry actually land the release) — and a second copy of
+ * this parser would be a second thing to update when a downstream is added, with nothing
+ * reporting the divergence. `scripts/render-targets.json` deliberately does NOT serve this role:
+ * it enumerates DISTRIBUTION targets and omits `minipuft-plugins` (a listing, not a
+ * distribution) and `codex-prompts`, so reading it here would silently audit three of five.
+ *
+ * `name` is parsed alongside `repo` because it selects the probe: the marketplace entry carries a
+ * literal version, the npm consumers carry a resolved lock version, and those are read from
+ * different files. A parser that dropped `name` would force the caller to re-derive the mapping
+ * from the repo slug, which is exactly the hardcoded second list this module exists to prevent.
+ */
+
+/**
+ * @param {string} source Raw `extension-publish.yml` contents.
+ * @returns {Array<{repo: string, name?: string, mergeMode?: string}>} Entries in matrix order.
+ */
+export function parseDownstreamMatrix(source) {
+  const matrixStart = source.indexOf('      matrix:\n');
+  const stepsStart = source.indexOf('    steps:\n', matrixStart);
+  if (matrixStart === -1 || stepsStart === -1) return [];
+  const matrix = source.slice(matrixStart, stepsStart);
+  const entries = [];
+  let current;
+  for (const line of matrix.split(/\r?\n/)) {
+    const repo = line.match(/^\s+- repo:\s*(\S+)\s*$/);
+    if (repo) {
+      current = { repo: repo[1] };
+      entries.push(current);
+      continue;
+    }
+    if (!current) continue;
+    const name = line.match(/^\s+name:\s*(\S+)\s*$/);
+    if (name) {
+      current.name = name[1];
+      continue;
+    }
+    const mode = line.match(/^\s+merge_mode:\s*(\S+)\s*$/);
+    if (mode) current.mergeMode = mode[1];
+  }
+  return entries;
+}

--- a/server/scripts/run-validation-suite.js
+++ b/server/scripts/run-validation-suite.js
@@ -167,6 +167,13 @@ export const SUITE = [
     converse: 'unexamined',
   },
   {
+    script: 'verify:downstream-sync:self-test',
+    io: 'read',
+    reads: ['file', 'spawn'],
+    converse:
+      'CHECKED both ways — a downstream behind the release is reported, and one at the release passes; the grace window suppresses drift findings but NOT unreadable ones, each proven separately',
+  },
+  {
     script: 'validate:readme',
     io: 'read',
     reads: ['file', 'index', 'spawn', 'tracked', 'walk'],

--- a/server/scripts/validate-documented-options.js
+++ b/server/scripts/validate-documented-options.js
@@ -57,6 +57,7 @@ const NOT_OUR_OPTIONS = new Set([
   '--tags', // git push --tags
   '--title', // gh release create
   '--notes', // gh release create
+  '--auto', // gh pr merge --auto
   '--plugin-dir', // claude --plugin-dir
   '--print', // claude --print
   '--strict', // npm run validate:identity-backfill -- --strict

--- a/server/scripts/validate-release-workflow.js
+++ b/server/scripts/validate-release-workflow.js
@@ -6,6 +6,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { parseDownstreamMatrix } from './lib/downstream-matrix.js';
+
 const ROOT_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const WORKFLOW = join(ROOT_DIR, '.github', 'workflows', 'extension-publish.yml');
 const MERGE_MODES = new Set(['auto']);
@@ -15,29 +17,9 @@ const REQUIRED_RELEASE_PATHS = [
   'claude-prompts-${{ steps.version.outputs.version }}-sourcemaps.tar.gz',
 ];
 
-function downstreamEntries(source) {
-  const matrixStart = source.indexOf('      matrix:\n');
-  const stepsStart = source.indexOf('    steps:\n', matrixStart);
-  if (matrixStart === -1 || stepsStart === -1) return [];
-  const matrix = source.slice(matrixStart, stepsStart);
-  const entries = [];
-  let current;
-  for (const line of matrix.split(/\r?\n/)) {
-    const repo = line.match(/^\s+- repo:\s*(\S+)\s*$/);
-    if (repo) {
-      current = { repo: repo[1] };
-      entries.push(current);
-      continue;
-    }
-    const mode = line.match(/^\s+merge_mode:\s*(\S+)\s*$/);
-    if (mode && current) current.mergeMode = mode[1];
-  }
-  return entries;
-}
-
 function findViolations(source) {
   const violations = [];
-  const entries = downstreamEntries(source);
+  const entries = parseDownstreamMatrix(source);
   if (entries.length === 0) violations.push('downstream matrix has no repositories');
   for (const entry of entries) {
     if (!entry.mergeMode) violations.push(`${entry.repo} has no merge_mode`);

--- a/server/scripts/validate-renovate-extraction.js
+++ b/server/scripts/validate-renovate-extraction.js
@@ -8,6 +8,10 @@ const ACTION_FILES = [
   '.github/workflows/ci.yml',
   // `downstream-sync.yml` was removed here 2026-08-13 with the workflow itself. `fileCount` below
   // is a FILE count and line 159 asserts this exact set, so the two move together — 8 → 7.
+  // `downstream-sync-audit.yml` was added 2026-08-15, restoring 7 → 8 by the same pairing. Note
+  // it is a DIFFERENT workflow from the one removed above: that one was a dead
+  // `repository_dispatch` chain, this one reads downstream merge state on a schedule.
+  '.github/workflows/downstream-sync-audit.yml',
   '.github/workflows/extension-publish.yml',
   '.github/workflows/npm-publish.yml',
   '.github/workflows/registry-publish.yml',
@@ -15,7 +19,7 @@ const ACTION_FILES = [
   '.github/workflows/renovate-config-validator.yml',
 ];
 const PACKAGE_FILES = ['cli/package.json', 'package.json', 'server/package.json'];
-const EXPECTED_COUNTS = { 'github-actions': 7, nodenv: 1, npm: 3, regex: 5 };
+const EXPECTED_COUNTS = { 'github-actions': 8, nodenv: 1, npm: 3, regex: 5 };
 const EXPECTED_REGEX_IDENTITIES = [
   ['PyYAML', '.github/workflows/ci.yml'],
   ['pyrefly', '.github/workflows/ci.yml'],

--- a/server/scripts/validate-suite-membership.js
+++ b/server/scripts/validate-suite-membership.js
@@ -96,6 +96,13 @@ const ALLOWED_OUTSIDE = [
     runBy: ['.github/workflows/npm-publish.yml'],
   },
   {
+    script: 'verify:downstream-sync',
+    reason:
+      'reads four other repositories over the network and grades their merge state; a suite that gates every commit cannot depend on downstream CI having finished',
+    closedBy: 'never, while the check is about repositories this suite does not control',
+    runBy: ['.github/workflows/downstream-sync-audit.yml'],
+  },
+  {
     script: 'validate:renovate-extraction',
     reason:
       'reads Renovate dry-run JSONL on stdin; a SUITE step runs with stdin ignored, so it is structurally ineligible',

--- a/server/scripts/verify-downstream-sync.js
+++ b/server/scripts/verify-downstream-sync.js
@@ -1,0 +1,349 @@
+#!/usr/bin/env node
+
+/**
+ * Did the release actually LAND downstream, or was it only sent?
+ *
+ * `extension-publish.yml`'s `sync-downstream` job validates hard before it opens a PR — `npm ci`
+ * agreement, an exact resolved lock version, marketplace url/ref/version assertions — and then
+ * ends at `gh pr merge --auto`. Auto-merge lands the PR WHEN THE DOWNSTREAM'S OWN CI PASSES. If
+ * that CI fails, or a required review never arrives, or the PR is closed, the PR sits open
+ * forever and the upstream release is already green. Nothing upstream ever learns.
+ *
+ * The matrix is `fail-fast: false`, so the same silence covers a leg that never got that far:
+ * the v4.0.0 run (2026-08-15) failed `codex-prompts` on a token permission at checkout while the
+ * other three synced, and the only surface signal was a workflow-level red that reads identically
+ * to "the release broke". Per-job truth existed; nothing asserted the FLEET.
+ *
+ * So this check reads the landed state on each downstream's default branch and compares it to the
+ * released version. It answers "they got it", where every existing gate answers "we sent it".
+ *
+ * DELIBERATELY NOT `RELEASE_PLEASE_TOKEN`. That token going stale is one of the conditions this
+ * check exists to detect; authenticating with it would make the detector fail in the same breath
+ * as the thing it detects, and a detector that dies with its subject reports nothing. All four
+ * downstreams are public, so the default workflow token reads them.
+ *
+ * NOT IN `validate:all`. It makes network calls to four other repositories and depends on their
+ * merge state, neither of which belongs in a suite that gates every commit. It runs on a schedule
+ * — detection, not prevention. `validate-suite-membership.js` carries the declared exception and
+ * asserts the scheduled workflow still names it.
+ *
+ * MECHANISM: script — relation — compares a CI workflow matrix against files fetched from four
+ * other repositories; no linter can see across repository boundaries
+ *
+ * Usage:
+ *   node scripts/verify-downstream-sync.js [--version 4.0.1] [--grace-hours 24] [--json]
+ *   node scripts/verify-downstream-sync.js --self-test
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+import { parseDownstreamMatrix } from './lib/downstream-matrix.js';
+
+const ROOT_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const WORKFLOW = join(ROOT_DIR, '.github', 'workflows', 'extension-publish.yml');
+const UPSTREAM_REPO = 'minipuft/claude-prompts-mcp';
+const ENGINE_PACKAGE = 'claude-prompts';
+
+/**
+ * How each downstream's INSTALLED engine version is read, keyed by the matrix `name`.
+ *
+ * An unrecognized name is an error rather than a skip, for the reason `render-targets.json`
+ * gives about `renderKind`: a target with no declared probe would otherwise be audited in
+ * silence, and "four of five checked" reports the same green as five of five. Adding a
+ * downstream to the matrix therefore forces a decision here.
+ */
+const PROBES = {
+  marketplace: {
+    path: '.claude-plugin/marketplace.json',
+    describe: 'marketplace listing version',
+    // The listing carries a literal version that sync-downstream jq-writes. Reading the lock
+    // instead would find nothing: this repo lists the plugin, it does not depend on the engine.
+    read(text) {
+      const listing = JSON.parse(text);
+      const entry = (listing.plugins ?? []).find((plugin) => plugin.name === ENGINE_PACKAGE);
+      if (!entry) throw new Error(`no ${ENGINE_PACKAGE} entry in the marketplace listing`);
+      if (!entry.version) throw new Error(`the ${ENGINE_PACKAGE} entry carries no version`);
+      return entry.version;
+    },
+  },
+  gemini: npmLockProbe(),
+  opencode: npmLockProbe(),
+  codex: npmLockProbe(),
+};
+
+function npmLockProbe() {
+  return {
+    path: 'package-lock.json',
+    describe: 'resolved lockfile version',
+    // The lock, not the `dependencies` range. sync-downstream writes `^MAJOR.0.0`, so a patch
+    // release leaves package.json byte-identical — the range is structurally incapable of
+    // distinguishing 4.0.0 from 4.0.1. Only the lock records which version is actually installed.
+    read(text) {
+      const lock = JSON.parse(text);
+      const version = lock.packages?.[`node_modules/${ENGINE_PACKAGE}`]?.version;
+      if (!version) throw new Error(`${ENGINE_PACKAGE} is absent from the lockfile`);
+      return version;
+    },
+  };
+}
+
+/** Matrix entries joined to their probe. Throws when a downstream has no declared probe. */
+export function resolveTargets(workflowSource) {
+  const entries = parseDownstreamMatrix(workflowSource);
+  if (entries.length === 0) throw new Error('the downstream sync matrix has no repositories');
+  return entries.map((entry) => {
+    if (!entry.name) throw new Error(`${entry.repo} has no matrix name, so no probe can be chosen`);
+    const probe = PROBES[entry.name];
+    if (!probe) {
+      throw new Error(
+        `${entry.repo} (name: ${entry.name}) has no declared probe in verify-downstream-sync.js — ` +
+          'add one rather than letting this downstream go unaudited'
+      );
+    }
+    return { ...entry, probe };
+  });
+}
+
+/**
+ * Grade observations against the released version.
+ *
+ * `withinGrace` suppresses drift findings, not read failures: immediately after a release the
+ * downstream PRs are legitimately open and auto-merge is still waiting on their CI, so flagging
+ * them would make every release day red and train the signal to be ignored. A downstream we
+ * cannot READ is reported regardless of grace — that is not "not landed yet", it is "this audit
+ * cannot see this repository", and a probe that cannot fire is the failure mode this whole file
+ * is modelled on.
+ */
+export function evaluate({ expectedVersion, observations, withinGrace = false }) {
+  const findings = [];
+  for (const observation of observations) {
+    if (observation.error) {
+      findings.push({
+        repo: observation.repo,
+        severity: 'unreadable',
+        message: `could not read ${observation.probePath}: ${observation.error}`,
+      });
+      continue;
+    }
+    if (observation.version === expectedVersion) continue;
+    findings.push({
+      repo: observation.repo,
+      severity: withinGrace ? 'pending' : 'drifted',
+      message: `${observation.describe} is ${observation.version}, released ${expectedVersion}`,
+    });
+  }
+  const blocking = findings.filter((finding) => finding.severity !== 'pending');
+  return { findings, ok: blocking.length === 0 };
+}
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+function fetchFile(repo, path) {
+  return gh(['api', `repos/${repo}/contents/${path}`, '-H', 'Accept: application/vnd.github.raw']);
+}
+
+function fetchLatestRelease() {
+  const release = JSON.parse(gh(['api', `repos/${UPSTREAM_REPO}/releases/latest`]));
+  return { version: String(release.tag_name).replace(/^v/, ''), publishedAt: release.published_at };
+}
+
+/**
+ * Read the value after a flag whose index the CALLER resolved.
+ *
+ * The `process.argv.indexOf('--flag')` call stays at the call site rather than moving in here,
+ * because that literal-in-idiom form is what `validate-documented-options.js` harvests as this
+ * project's flag surface. Passing the flag name into a helper hides it: the flag would be real,
+ * documented, and read as unbacked — the guard would fail on correct docs.
+ */
+function valueAfter(index, fallback) {
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+function runSelfTest() {
+  const cases = [
+    {
+      rule: 'a downstream behind the release is reported',
+      run: () =>
+        !evaluate({
+          expectedVersion: '4.0.1',
+          observations: [{ repo: 'o/r', version: '4.0.0', describe: 'lock' }],
+        }).ok,
+    },
+    {
+      rule: 'a downstream at the release passes',
+      run: () =>
+        evaluate({
+          expectedVersion: '4.0.1',
+          observations: [{ repo: 'o/r', version: '4.0.1', describe: 'lock' }],
+        }).ok,
+    },
+    {
+      rule: 'drift inside the grace window is pending, not blocking',
+      run: () =>
+        evaluate({
+          expectedVersion: '4.0.1',
+          observations: [{ repo: 'o/r', version: '4.0.0', describe: 'lock' }],
+          withinGrace: true,
+        }).ok,
+    },
+    {
+      rule: 'an unreadable downstream is reported EVEN inside the grace window',
+      run: () =>
+        !evaluate({
+          expectedVersion: '4.0.1',
+          observations: [{ repo: 'o/r', error: 'HTTP 404', probePath: 'package-lock.json' }],
+          withinGrace: true,
+        }).ok,
+    },
+    {
+      rule: 'a matrix entry with no declared probe is an error, not a silent skip',
+      run: () => {
+        try {
+          resolveTargets(
+            '      matrix:\n        include:\n          - repo: o/new\n            name: brandnew\n            merge_mode: auto\n    steps:\n'
+          );
+          return false;
+        } catch (error) {
+          return /no declared probe/.test(error.message);
+        }
+      },
+    },
+    {
+      rule: 'an empty matrix is an error rather than a vacuous pass',
+      run: () => {
+        try {
+          resolveTargets('      matrix:\n        include:\n    steps:\n');
+          return false;
+        } catch (error) {
+          return /no repositories/.test(error.message);
+        }
+      },
+    },
+    {
+      rule: 'the real workflow matrix resolves a probe for every downstream',
+      run: () => resolveTargets(readFileSync(WORKFLOW, 'utf8')).length >= 4,
+    },
+    {
+      rule: 'the lock probe reads the resolved version, not the declared range',
+      run: () =>
+        PROBES.gemini.read(
+          JSON.stringify({
+            packages: { [`node_modules/${ENGINE_PACKAGE}`]: { version: '4.0.1' } },
+          })
+        ) === '4.0.1',
+    },
+    {
+      rule: 'the marketplace probe rejects a listing whose entry lost its version',
+      run: () => {
+        try {
+          PROBES.marketplace.read(JSON.stringify({ plugins: [{ name: ENGINE_PACKAGE }] }));
+          return false;
+        } catch (error) {
+          return /carries no version/.test(error.message);
+        }
+      },
+    },
+  ];
+  let failures = 0;
+  for (const { rule, run } of cases) {
+    // `passed` stays false when `run()` throws: the assignment never completes, so the catch
+    // has nothing to reset and re-assigning there is dead (no-useless-assignment).
+    let passed = false;
+    try {
+      passed = run() === true;
+    } catch (error) {
+      console.error(`    ${error.message}`);
+    }
+    console.log(`  ${passed ? 'ok  ' : 'FAIL'}  ${rule}`);
+    if (!passed) failures += 1;
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+function main() {
+  if (process.argv.includes('--self-test')) return runSelfTest();
+
+  const graceHours = Number(valueAfter(process.argv.indexOf('--grace-hours'), '24'));
+  if (!Number.isFinite(graceHours) || graceHours < 0) {
+    console.error('ERROR: --grace-hours must be a non-negative number');
+    process.exitCode = 1;
+    return;
+  }
+
+  let targets;
+  try {
+    targets = resolveTargets(readFileSync(WORKFLOW, 'utf8'));
+  } catch (error) {
+    console.error(`ERROR: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const override = valueAfter(process.argv.indexOf('--version'), null);
+  let expectedVersion = override;
+  let withinGrace = false;
+  if (!override) {
+    const release = fetchLatestRelease();
+    expectedVersion = release.version;
+    const ageHours = (Date.now() - Date.parse(release.publishedAt)) / 3_600_000;
+    withinGrace = ageHours < graceHours;
+    console.log(
+      `Released ${expectedVersion} ${ageHours.toFixed(1)}h ago` +
+        (withinGrace ? ` — inside the ${graceHours}h auto-merge grace window` : '')
+    );
+  }
+
+  const observations = targets.map((target) => {
+    try {
+      return {
+        repo: target.repo,
+        describe: target.probe.describe,
+        probePath: target.probe.path,
+        version: target.probe.read(fetchFile(target.repo, target.probe.path)),
+      };
+    } catch (error) {
+      return {
+        repo: target.repo,
+        describe: target.probe.describe,
+        probePath: target.probe.path,
+        error: error.message.trim().split('\n').pop(),
+      };
+    }
+  });
+
+  const { findings, ok } = evaluate({ expectedVersion, observations, withinGrace });
+
+  for (const observation of observations) {
+    const state = observation.error ? `ERROR ${observation.error}` : observation.version;
+    console.log(`  ${observation.repo.padEnd(28)} ${observation.describe}: ${state}`);
+  }
+
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify({ expectedVersion, observations, findings, ok }, null, 2));
+  }
+
+  if (!ok) {
+    for (const finding of findings) {
+      if (finding.severity === 'pending') continue;
+      console.error(`::error::${finding.repo} ${finding.severity}: ${finding.message}`);
+    }
+    console.error(
+      `FAILED: ${findings.filter((f) => f.severity !== 'pending').length} downstream(s) did not land ${expectedVersion}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const pending = findings.filter((finding) => finding.severity === 'pending');
+  for (const finding of pending) console.log(`  PENDING ${finding.repo}: ${finding.message}`);
+  console.log(
+    `PASSED: ${observations.length - pending.length}/${observations.length} downstream(s) serve ${expectedVersion}`
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

- `sync-downstream` ends at `gh pr merge --auto`, which lands the PR **when the downstream's own CI passes**. If that CI fails or the PR is closed, the downstream stays on the old engine while the upstream release is already green — invisible from upstream by construction.
- New daily `Downstream Sync Audit` reads the **landed** state (marketplace listing version for `minipuft-plugins`, resolved lockfile version for the npm consumers) and fails when one is behind the published release.
- The matrix parser moves to `lib/downstream-matrix.js` and is now shared with `validate-release-workflow.js` instead of copied.

## Notes for Reviewers

**Why the lockfile, not the range.** `sync-downstream` writes `^MAJOR.0.0`, so a patch release leaves `package.json` byte-identical — the range is structurally incapable of distinguishing 4.0.0 from 4.0.1.

**Why the default token, never `RELEASE_PLEASE_TOKEN`.** That PAT going stale is one of the conditions this audit detects. A detector that authenticates with its own subject dies with it and reports nothing. All four downstreams are public.

**Why the target list comes from the sync matrix.** A downstream added to the matrix cannot go silently unaudited — an entry with no declared probe is an error, never a skip. This is the `renderKind` pattern from `render-targets.json`.

**Why scheduled, not chained onto the release.** "Did it land" is not knowable at release time; auto-merge has not resolved. A post-release run would either block the release on four other repos' CI or report pending as success. `--grace-hours` (default 24) keeps release day quiet, but an **unreadable** downstream is reported regardless — that is not "not landed yet", it is "this audit cannot see this repository".

**Overlap with the Fleet Drift Audit, deliberately not merged.** `repository-standards` audits resolved version weekly over `fleet.json` — a hand-maintained list in another repo that lists 3 repos and **omits `codex-prompts` entirely**, with no exclusion note. The one downstream that actually failed a sync had no drift coverage. Worth closing separately in that repo.

## Verification

- `validate:all` — 38/38 pass
- `test:ci` — 2481 tests, 190 suites pass
- Self-test — 9/9 rules, each proving it can fail
- Falsified live: `--version 4.0.1` correctly reports all four downstreams drifted, exit 1
- Live run: 4/4 serve 4.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9yQQCDXizeDdcov43yaXH